### PR TITLE
fix(docker): Use Node 16 image for NPM 7 (workspace support)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build
-FROM node:lts-alpine as build
+FROM node:16-alpine as build
 WORKDIR /usr/src/app
 
 # - install dependencies
@@ -13,7 +13,7 @@ COPY . .
 RUN npm run build-all
 
 # execution
-FROM node:lts-alpine
+FROM node:16-alpine
 WORKDIR /usr/src/app
 
 # - install PRODUCTION dependencies
@@ -22,13 +22,13 @@ COPY backend/package*.json ./backend/
 COPY frontend/package*.json ./frontend/
 RUN npm ci --production
 
-# add the already compiled code
+# - add the already compiled code
 COPY --from=build /usr/src/app/server.js ./
 COPY --from=build /usr/src/app/backend/build ./backend/build
 COPY --from=build /usr/src/app/frontend/build ./frontend/build
 
-# we listen on :8080
+# - ports
 EXPOSE 8080
 
-# start the server ("production" skips the build step)
+# - start the server ("production" skips the build step)
 CMD ["npm", "run", "production"]


### PR DESCRIPTION
The CI failed because lts-alpine only has NPM v6, which does not support
workspaces, so the image could not be built as expected.