### PR TITLE
refactor(websocket): Use plain ws instead of express-ws

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -10,8 +10,8 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.13",
-    "@types/express-ws": "^3.0.1",
     "@types/node": "^16.9.3",
+    "@types/ws": "^7.4.7",
     "rimraf": "^3.0.2",
     "typescript": "^4.4.3"
   },

--- a/backend/websocket/handler.ts
+++ b/backend/websocket/handler.ts
@@ -1,7 +1,7 @@
-import { WebsocketRequestHandler } from 'express-ws'
+import WebSocket from 'ws'
 import { register } from './events'
 
-export const handler: WebsocketRequestHandler = (ws) => {
+export const webSocketHandler = (ws: WebSocket): void => {
   const unsubscribe = register(ws)
 
   ws.on('close', unsubscribe)

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       ],
       "dependencies": {
         "express": "^4.17.1",
-        "express-ws": "^5.0.2"
+        "ws": "^8.2.2"
       },
       "devDependencies": {
         "eslint": "^7.32.0",
@@ -32,8 +32,8 @@
       },
       "devDependencies": {
         "@types/express": "^4.17.13",
-        "@types/express-ws": "^3.0.1",
         "@types/node": "^16.9.3",
+        "@types/ws": "^7.4.7",
         "rimraf": "^3.0.2",
         "typescript": "^4.4.3"
       }
@@ -3479,17 +3479,6 @@
         "@types/node": "*",
         "@types/qs": "*",
         "@types/range-parser": "*"
-      }
-    },
-    "node_modules/@types/express-ws": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/express-ws/-/express-ws-3.0.1.tgz",
-      "integrity": "sha512-VguRXzcpPBF0IggIGpUoM65cZJDfMQxoc6dKoCz1yLzcwcXW7ft60yhq3ygKhyEhEIQFtLrWjyz4AJ1qjmzCFw==",
-      "dev": true,
-      "dependencies": {
-        "@types/express": "*",
-        "@types/express-serve-static-core": "*",
-        "@types/ws": "*"
       }
     },
     "node_modules/@types/glob": {
@@ -9478,20 +9467,6 @@
         "node": ">= 0.10.0"
       }
     },
-    "node_modules/express-ws": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/express-ws/-/express-ws-5.0.2.tgz",
-      "integrity": "sha512-0uvmuk61O9HXgLhGl3QhNSEtRsQevtmbL94/eILaliEADZBHZOQUAiHFrGPrgsjikohyrmSG5g+sCfASTt0lkQ==",
-      "dependencies": {
-        "ws": "^7.4.6"
-      },
-      "engines": {
-        "node": ">=4.5.0"
-      },
-      "peerDependencies": {
-        "express": "^4.0.0 || ^5.0.0-alpha.1"
-      }
-    },
     "node_modules/express/node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -13687,6 +13662,27 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/jsdom/node_modules/ws": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
+      "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsesc": {
@@ -24468,11 +24464,11 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
-      "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.2.tgz",
+      "integrity": "sha512-Q6B6H2oc8QY3llc3cB8kVmQ6pnJWVQbP7Q5algTcIxx7YEpc0oU4NBVHlztA7Ekzfhw2r0rPducMUiCGWKQRzw==",
       "engines": {
-        "node": ">=8.3.0"
+        "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
@@ -27144,17 +27140,6 @@
         "@types/range-parser": "*"
       }
     },
-    "@types/express-ws": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/express-ws/-/express-ws-3.0.1.tgz",
-      "integrity": "sha512-VguRXzcpPBF0IggIGpUoM65cZJDfMQxoc6dKoCz1yLzcwcXW7ft60yhq3ygKhyEhEIQFtLrWjyz4AJ1qjmzCFw==",
-      "dev": true,
-      "requires": {
-        "@types/express": "*",
-        "@types/express-serve-static-core": "*",
-        "@types/ws": "*"
-      }
-    },
     "@types/glob": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.4.tgz",
@@ -28698,8 +28683,8 @@
       "version": "file:backend",
       "requires": {
         "@types/express": "^4.17.13",
-        "@types/express-ws": "^3.0.1",
         "@types/node": "^16.9.3",
+        "@types/ws": "^7.4.7",
         "joi": "^17.4.2",
         "mongoose": "^6.0.6",
         "rimraf": "^3.0.2",
@@ -31964,14 +31949,6 @@
         }
       }
     },
-    "express-ws": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/express-ws/-/express-ws-5.0.2.tgz",
-      "integrity": "sha512-0uvmuk61O9HXgLhGl3QhNSEtRsQevtmbL94/eILaliEADZBHZOQUAiHFrGPrgsjikohyrmSG5g+sCfASTt0lkQ==",
-      "requires": {
-        "ws": "^7.4.6"
-      }
-    },
     "ext": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/ext/-/ext-1.5.0.tgz",
@@ -35206,6 +35183,13 @@
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
           "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
           "dev": true
+        },
+        "ws": {
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
+          "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -43942,9 +43926,9 @@
       }
     },
     "ws": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
-      "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.2.tgz",
+      "integrity": "sha512-Q6B6H2oc8QY3llc3cB8kVmQ6pnJWVQbP7Q5algTcIxx7YEpc0oU4NBVHlztA7Ekzfhw2r0rPducMUiCGWKQRzw==",
       "requires": {}
     },
     "xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
   },
   "dependencies": {
     "express": "^4.17.1",
-    "express-ws": "^5.0.2"
+    "ws": "^8.2.2"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,24 +1,37 @@
 'use strict'
 
 const express = require('express')
+const path = require('path')
+const { Server: WebSocketServer } = require('ws')
 
 const { init, createApiRouter } = require('./backend/build/index')
-const { handler: webSocketHandler } = require('./backend/build/websocket/handler')
+const { webSocketHandler } = require('./backend/build/websocket/handler')
 
 async function start () {
   init(process.env)
 
   const app = express()
-  require('express-ws')(app)
 
   app.use(express.json())
 
   // the project needs to be built (`npm run build`) before these paths can work!
   app.use('/api', createApiRouter())
-  app.ws('/websocket', webSocketHandler)
   app.use(express.static('./frontend/build'))
+  // redirect all other requests to index.html for React-Router to handle
+  app.get('*', (req, res) => {
+    res.sendFile(path.join(__dirname, './frontend/build/index.html'))
+  })
 
-  app.listen(8080, '::')
+  const server = app.listen(8080, '::')
+
+  const wsServer = new WebSocketServer({ noServer: true })
+  wsServer.on('connection', webSocketHandler)
+
+  server.on('upgrade', (req, socket, head) => {
+    if (req.url === '/websocket' || req.url === '/websocket/') {
+      wsServer.handleUpgrade(req, socket, head, ws => wsServer.emit('connection', ws, req))
+    }
+  })
 }
 
 start()


### PR DESCRIPTION
Since express-ws is outdated and buggy, we now use plain ws for the
WebSocket server.