### PR TITLE
feat(pages): Implement NavigationBarLayout to center content

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,4 +1,0 @@
-.App {
-  margin-left: 60px;
-  padding: 8px;
-}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,4 @@
-import './App.css'
 import { ReactElement } from 'react'
-import NavigationBar from './components/NavigationBar'
 import { BrowserRouter, Route, Switch } from 'react-router-dom'
 import HomePage from './pages/HomePage'
 import MembersPage from './pages/MembersPage'
@@ -13,28 +11,24 @@ export default function App (): ReactElement {
   useApiSliceBridge('members', membersActions)
 
   return (
-    <div className='App'>
-      <BrowserRouter>
-        <NavigationBar />
+    <BrowserRouter>
+      <Switch>
+        {/* home page */}
+        <Route exact path='/'>
+          <HomePage />
+        </Route>
 
-        <Switch>
-          {/* home page */}
-          <Route exact path='/'>
-            <HomePage />
-          </Route>
-
-          {/* settings pages */}
-          <Route exact path='/settings/members'>
-            <MembersPage />
-          </Route>
-          <Route exact path='/settings/cleaning'>
-            <CleaningPage />
-          </Route>
-          <Route exact path='/settings/garbage'>
-            <GarbageDisposalPage />
-          </Route>
-        </Switch>
-      </BrowserRouter>
-    </div>
+        {/* settings pages */}
+        <Route exact path='/settings/members'>
+          <MembersPage />
+        </Route>
+        <Route exact path='/settings/cleaning'>
+          <CleaningPage />
+        </Route>
+        <Route exact path='/settings/garbage'>
+          <GarbageDisposalPage />
+        </Route>
+      </Switch>
+    </BrowserRouter>
   )
 }

--- a/frontend/src/layouts/NavigationBarLayout.css
+++ b/frontend/src/layouts/NavigationBarLayout.css
@@ -1,0 +1,10 @@
+.NavigationBarLayout {
+  margin-left: 60px;
+  padding: 24px 8px;
+}
+
+.NavigationBarLayout.centered > .NavigationBarLayout-content {
+  width: 80%;
+  max-width: 800px;
+  margin: auto;
+}

--- a/frontend/src/layouts/NavigationBarLayout.tsx
+++ b/frontend/src/layouts/NavigationBarLayout.tsx
@@ -1,0 +1,18 @@
+import './NavigationBarLayout.css'
+import { PropsWithChildren, ReactElement } from 'react'
+import NavigationBar from '../components/NavigationBar'
+
+interface Props {
+  centered?: boolean
+}
+
+export default function NavigationBarLayout (props: PropsWithChildren<Props>): ReactElement {
+  return (
+    <div className={'NavigationBarLayout' + (props.centered === true ? ' centered' : '')}>
+      <NavigationBar />
+      <div className='NavigationBarLayout-content'>
+        {props.children}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/CleaningPage.tsx
+++ b/frontend/src/pages/CleaningPage.tsx
@@ -1,11 +1,14 @@
 import { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 import PageTitle from '../components/PageTitle'
+import NavigationBarLayout from '../layouts/NavigationBarLayout'
 
 export default function CleaningPage (): ReactElement {
   const { t } = useTranslation()
 
   return (
-    <PageTitle title={t('cleaning.title')} />
+    <NavigationBarLayout centered>
+      <PageTitle title={t('cleaning.title')} />
+    </NavigationBarLayout>
   )
 }

--- a/frontend/src/pages/GarbageDisposalPage.tsx
+++ b/frontend/src/pages/GarbageDisposalPage.tsx
@@ -1,11 +1,14 @@
 import { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 import PageTitle from '../components/PageTitle'
+import NavigationBarLayout from '../layouts/NavigationBarLayout'
 
 export default function GarbageDisposalPage (): ReactElement {
   const { t } = useTranslation()
 
   return (
-    <PageTitle title={t('garbage.title')} />
+    <NavigationBarLayout centered>
+      <PageTitle title={t('garbage.title')} />
+    </NavigationBarLayout>
   )
 }

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,11 +1,14 @@
 import { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 import PageTitle from '../components/PageTitle'
+import NavigationBarLayout from '../layouts/NavigationBarLayout'
 
 export default function HomePage (): ReactElement {
   const { t } = useTranslation()
 
   return (
-    <PageTitle title={t('home.title')} />
+    <NavigationBarLayout>
+      <PageTitle title={t('home.title')} />
+    </NavigationBarLayout>
   )
 }

--- a/frontend/src/pages/MembersPage.tsx
+++ b/frontend/src/pages/MembersPage.tsx
@@ -9,6 +9,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import MemberItem from '../components/members/MemberItem'
 import EditMemberModal from '../components/members/EditMemberModal'
 import api from '../api/api'
+import NavigationBarLayout from '../layouts/NavigationBarLayout'
 
 export default function MembersPage (): ReactElement {
   const { t } = useTranslation()
@@ -26,7 +27,7 @@ export default function MembersPage (): ReactElement {
   }, [])
 
   return (
-    <div>
+    <NavigationBarLayout centered>
       <PageTitle title={t('members.title')}>
         <BasicButton onClick={showCreateModal}>
           <FontAwesomeIcon icon={faPlus} />
@@ -37,6 +38,6 @@ export default function MembersPage (): ReactElement {
       {members.map(member => (
         <MemberItem key={member._id} member={member} />
       ))}
-    </div>
+    </NavigationBarLayout>
   )
 }


### PR DESCRIPTION
Page layouting is moved out of App and into a new NavigationBarLayout.
Via a prop, that component can optionally be configured to center the
page content.