### PR TITLE
feat: Indicate disconnected status via a modal

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import GarbageDisposalPage from './pages/GarbageDisposalPage'
 import { membersActions } from './store/entities/members'
 import { useApiSliceBridge } from './api-slice-bridge'
 import { manualChoresActions } from './store/entities/manual-chores'
+import ConnectionModal from './components/ConnectionModal'
 
 export default function App (): ReactElement {
   useApiSliceBridge('members', membersActions)
@@ -31,6 +32,9 @@ export default function App (): ReactElement {
           <GarbageDisposalPage />
         </Route>
       </Switch>
+
+      {/* an overlay over the whole page displayed when connection is lost */}
+      <ConnectionModal />
     </BrowserRouter>
   )
 }

--- a/frontend/src/components/ConnectionModal.tsx
+++ b/frontend/src/components/ConnectionModal.tsx
@@ -1,0 +1,22 @@
+import { ReactElement } from 'react'
+import Modal from './modals/Modal'
+import { useConnectionStatusDebounced } from '../util/use-connection-status'
+import { useTranslation } from 'react-i18next'
+
+/**
+ * The time (in milliseconds) that it's okay to be disconnected. Only when the socket is disconnected longer than this
+ * will the overlay be shown.
+ */
+const ALLOWED_DISCONNECT_TIME = 3000
+
+export default function ConnectionModal (): ReactElement {
+  const { t } = useTranslation()
+
+  const connected = useConnectionStatusDebounced(ALLOWED_DISCONNECT_TIME)
+
+  return (
+    <Modal important active={!connected}>
+      {t('lostConnection')}
+    </Modal>
+  )
+}

--- a/frontend/src/components/modals/Modal.css
+++ b/frontend/src/components/modals/Modal.css
@@ -12,6 +12,10 @@
   justify-content: center;
 }
 
+.Modal.important {
+  z-index: 1000;
+}
+
 .Modal.active {
   display: flex;
 }

--- a/frontend/src/components/modals/Modal.tsx
+++ b/frontend/src/components/modals/Modal.tsx
@@ -6,6 +6,7 @@ import { useScrollLock } from '../../util/use-scroll-lock'
 
 interface Props {
   active: boolean
+  important?: boolean
 }
 
 export default function Modal (props: PropsWithChildren<Props>): ReactElement {
@@ -16,7 +17,7 @@ export default function Modal (props: PropsWithChildren<Props>): ReactElement {
     return <></>
   }
 
-  return createPortal(<div ref={ref} className={clsx('Modal', { active: props.active })}>
+  return createPortal(<div ref={ref} className={clsx('Modal', { active: props.active, important: props.important })}>
     <div className='Modal-container'>
       {props.children}
     </div>

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -1,4 +1,5 @@
 {
+  "lostConnection": "Verbindungsaufbau...",
   "basicActions": {
     "add": "Hinzufügen",
     "edit": "Bearbeiten",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1,4 +1,5 @@
 {
+  "lostConnection": "Trying to reconnect...",
   "basicActions": {
     "add": "Add",
     "edit": "Edit",

--- a/frontend/src/util/use-connection-status.ts
+++ b/frontend/src/util/use-connection-status.ts
@@ -1,0 +1,51 @@
+import socket from '../websocket/socket'
+import { useEffect, useState } from 'react'
+
+/**
+ * A custom hook that provides the WebSocket connection status.
+ *
+ * @returns Whether the socket is currently connected.
+ */
+export function useConnectionStatus (): boolean {
+  const [connected, setConnected] = useState(socket.connected)
+
+  useEffect(() => {
+    const connectListener = (): void => setConnected(true)
+    const disconnectListener = (): void => setConnected(false)
+    socket.on('connect', connectListener)
+    socket.on('disconnect', disconnectListener)
+    return () => {
+      socket.off('connect', connectListener)
+      socket.off('disconnect', disconnectListener)
+    }
+  }, [])
+
+  return connected
+}
+
+/**
+ * A custom hook that provides the WebSocket connection status, but with a specified "grace period" for disconnected
+ * state. The hook will continue to indicate the connected state for the given delay, and only if that delay is over
+ * will it switch to disconnected (unless the connection was restored).
+ *
+ * @param delay The amount of time the socket can be disconnected while still showing as connected.
+ * @returns Whether the socket is currently connected or was connected recently enough.
+ */
+export function useConnectionStatusDebounced (delay: number): boolean {
+  const [wasConnected, setWasConnected] = useState(true)
+
+  const connected = useConnectionStatus()
+
+  useEffect(() => {
+    // propagate restored connection immediately
+    if (connected) {
+      setWasConnected(true)
+      return
+    }
+    // apply a delay to disconnect propagation
+    const timeout = setTimeout(() => setWasConnected(false), delay)
+    return () => clearTimeout(timeout)
+  }, [connected, delay])
+
+  return wasConnected
+}


### PR DESCRIPTION
When the socket is disconnected for over 3 seconds, a modal will be
shown until connection is restored. This prevents the user from
performing actions that might fail during that time.