### PR TITLE
feat(components): Display relativeScore as number in ScoreRow

### DIFF
--- a/frontend/src/components/home/ScoreRow.css
+++ b/frontend/src/components/home/ScoreRow.css
@@ -16,5 +16,8 @@
 .ScoreRow-bar-inner {
   display: block;
   height: 100%;
+  padding-left: 8px;
+  font-size: 14px;
+  font-weight: bold;
   background: #e95;
 }

--- a/frontend/src/components/home/ScoreRow.tsx
+++ b/frontend/src/components/home/ScoreRow.tsx
@@ -16,13 +16,17 @@ export default function ScoreRow (props: Props): ReactElement {
     return members.find(item => item._id === props.memberId)
   }, [members, props.memberId])
 
-  const badness = Math.abs(props.relativeScore / props.lowestScore)
+  const badness = props.lowestScore !== 0
+    ? Math.abs(props.relativeScore / props.lowestScore)
+    : 0
 
   return (
     <div className='ScoreRow'>
       <div className='ScoreRow-name'>{member?.name}</div>
       <div className='ScoreRow-bar'>
-        <span className='ScoreRow-bar-inner' style={{ width: (badness * 100).toFixed(0) + '%' }} />
+        <span className='ScoreRow-bar-inner' style={{ width: (badness * 100).toFixed(0) + '%' }}>
+          {props.relativeScore}
+        </span>
       </div>
     </div>
   )


### PR DESCRIPTION
Additionally, avoids a divide-by-zero problem when calculating badness.