### PR TITLE
style: Redesign EditableItem, ChoreBox, MemberItem color components

### DIFF
--- a/frontend/src/components/home/ChoreBox.css
+++ b/frontend/src/components/home/ChoreBox.css
@@ -6,7 +6,7 @@
   background: #fff;
   border: 2px solid transparent;
   border-radius: 2px;
-  box-shadow: 0 2px 6px 0 rgba(0, 0, 0, 0.1);
+  box-shadow: 0 6px 12px 0 rgba(0, 0, 0, 0.1);
 }
 
 .ChoreBox.urgent {

--- a/frontend/src/components/home/SelectMemberButton.css
+++ b/frontend/src/components/home/SelectMemberButton.css
@@ -2,11 +2,11 @@
   display: inline-block;
   min-width: 120px;
   margin: 0;
-  padding: 32px 12px;
+  padding: 24px 12px;
   font: inherit;
   font-size: 20px;
   background: #fff;
-  border: 4px solid #ccc;
+  border: 6px solid #ccc;
   border-radius: 4px;
   cursor: pointer;
 }

--- a/frontend/src/components/items/EditableItem.css
+++ b/frontend/src/components/items/EditableItem.css
@@ -1,15 +1,18 @@
 .EditableItem {
   display: flex;
-  margin: 16px 0;
+  margin: 10px 0;
   padding: 12px;
   align-items: center;
   background: #fff;
-  border: 2px solid #b1b1b1;
+  border: 2px solid transparent;
+  border-radius: 2px;
+  box-shadow: 0 8px 16px 0 rgba(0, 0, 0, 0.1);
 }
 
 .EditableItem-name {
   flex-grow: 1;
   font-size: 20px;
+  vertical-align: middle;
 }
 
 .EditableItem-actions {

--- a/frontend/src/components/items/EditableItem.tsx
+++ b/frontend/src/components/items/EditableItem.tsx
@@ -1,5 +1,5 @@
 import './EditableItem.css'
-import { CSSProperties, PropsWithChildren, ReactElement } from 'react'
+import { CSSProperties, PropsWithChildren, ReactElement, ReactNode } from 'react'
 import clsx from 'clsx'
 import BasicButton from '../forms/BasicButton'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -9,7 +9,7 @@ import { useTranslation } from 'react-i18next'
 interface Props {
   className?: string
   style?: CSSProperties
-  itemName: string
+  itemName: ReactNode
   onClickEdit: () => void
 }
 

--- a/frontend/src/components/members/MemberItem.css
+++ b/frontend/src/components/members/MemberItem.css
@@ -1,3 +1,8 @@
-.MemberItem {
-  border-width: 6px !important;
+.MemberItem-color {
+  display: inline-block;
+  width: 32px;
+  height: 32px;
+  margin-right: 16px;
+  border-radius: 4px;
+  vertical-align: middle;
 }

--- a/frontend/src/components/members/MemberItem.tsx
+++ b/frontend/src/components/members/MemberItem.tsx
@@ -20,10 +20,17 @@ export default function MemberItem (props: Props): ReactElement {
     setEditing(false)
   }, [])
 
-  const style = useMemo<CSSProperties>(() => ({ borderColor: props.member.color }), [props.member.color])
+  const style = useMemo<CSSProperties>(() => ({ background: props.member.color }), [props.member.color])
+
+  const itemName = (
+    <>
+      <div className='MemberItem-color' style={style} />
+      {props.member.name}
+    </>
+  )
 
   return (
-    <EditableItem className='MemberItem' style={style} itemName={props.member.name} onClickEdit={showEditModal}>
+    <EditableItem className='MemberItem' itemName={itemName} onClickEdit={showEditModal}>
       <EditMemberModal member={props.member} active={editing} onSave={save} onCancel={hideEditModal} />
     </EditableItem>
   )

--- a/frontend/src/components/modals/Modal.css
+++ b/frontend/src/components/modals/Modal.css
@@ -24,7 +24,7 @@
   position: relative;
   padding: 24px 32px;
   background-color: #fff;
-  box-shadow: 0 0 30px 0 rgba(0, 0, 0, 0.25);
+  box-shadow: 0 0 24px 0 rgba(0, 0, 0, 0.25);
   border-radius: 4px;
   overflow-y: hidden;
 }


### PR DESCRIPTION
Removes most strong borders in favor of very soft shadows, and in the
case of MemberItem, a colored square instead of the colored border.
SelectMemberButton is slightly updated and the Modal shadow is reduced
a bit because it was unnecessarily large.