### PR TITLE
feat(api): Handle errors in Express, e.g. malformed JSON

### DIFF
--- a/backend/api/api.ts
+++ b/backend/api/api.ts
@@ -1,5 +1,5 @@
-import { Router } from 'express'
-import { createHandler } from './create-handler'
+import { ErrorRequestHandler, Router } from 'express'
+import { createHandler, handleError } from './create-handler'
 import { NotFoundError } from './errors'
 import { Controller } from '../controllers/controller'
 import { createControllerRoute } from './controller-route'
@@ -26,4 +26,13 @@ export function createApiRouter (): Router {
   }))
 
   return router
+}
+
+export function createApiErrorHandler (): ErrorRequestHandler {
+  return (err, req, res, next) => {
+    if (res.headersSent) {
+      return next(err)
+    }
+    handleError(err, res)
+  }
 }

--- a/backend/api/constants.ts
+++ b/backend/api/constants.ts
@@ -1,0 +1,5 @@
+export const HTTP_OK = 200
+export const HTTP_CREATED = 201
+export const HTTP_BAD_REQUEST = 400
+export const HTTP_NOT_FOUND = 404
+export const HTTP_INTERNAL_SERVER_ERROR = 500

--- a/backend/api/controller-route.ts
+++ b/backend/api/controller-route.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express'
-import { createHandler, HTTP_CREATED } from './create-handler'
+import { createHandler } from './create-handler'
 import { Controller } from '../controllers/controller'
+import { HTTP_CREATED } from './constants'
 
 export function createControllerRoute (controller: Controller<any>): Router {
   const router = Router()

--- a/backend/api/errors.ts
+++ b/backend/api/errors.ts
@@ -1,3 +1,5 @@
+import { HTTP_BAD_REQUEST, HTTP_NOT_FOUND } from './constants'
+
 /**
  * A special type of error that is intentionally thrown by the API.
  * It includes a HTTP status code and a message string.
@@ -19,7 +21,7 @@ export class ApiError extends Error {
  */
 export class BadRequestError extends ApiError {
   constructor (message: string) {
-    super(400, message)
+    super(HTTP_BAD_REQUEST, message)
   }
 }
 
@@ -28,6 +30,6 @@ export class BadRequestError extends ApiError {
  */
 export class NotFoundError extends ApiError {
   constructor (object: string = 'resource') {
-    super(404, `${object} not found`)
+    super(HTTP_NOT_FOUND, `${object} not found`)
   }
 }

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -1,7 +1,8 @@
 import mongoose from 'mongoose'
 import { Environment } from './environment'
 
-export { createApiRouter } from './api/api'
+export { createApiRouter, createApiErrorHandler } from './api/api'
+export { webSocketHandler } from './websocket/handler'
 
 export async function init (env: Environment): Promise<void> {
   mongoose.set('toJSON', {

--- a/server.js
+++ b/server.js
@@ -4,8 +4,7 @@ const express = require('express')
 const path = require('path')
 const { Server: WebSocketServer } = require('ws')
 
-const { init, createApiRouter } = require('./backend/build/index')
-const { webSocketHandler } = require('./backend/build/websocket/handler')
+const { init, createApiRouter, createApiErrorHandler, webSocketHandler } = require('./backend/build/index')
 
 async function start () {
   init(process.env)
@@ -21,6 +20,9 @@ async function start () {
   app.get('*', (req, res) => {
     res.sendFile(path.join(__dirname, './frontend/build/index.html'))
   })
+
+  // this will catch errors in express itself, and things missed by the routes
+  app.use(createApiErrorHandler())
 
   const server = app.listen(8080, '::')
 


### PR DESCRIPTION
Errors thrown by Express now no longer result in an HTML page but also
in one of our own error responses. This is especially important for
malformed JSON sent by clients which should always result in a code 400
response.