### PR TITLE
fix: Close edit-modal before update, to avoid WebSocket race condition

### DIFF
--- a/frontend/src/components/garbage/ManualChoreItem.tsx
+++ b/frontend/src/components/garbage/ManualChoreItem.tsx
@@ -15,8 +15,8 @@ export default function ManualChoreItem (props: Props): ReactElement {
   const hideEditModal = useCallback(() => setEditing(false), [])
 
   const save = useCallback(async (entity: ManualChore) => {
-    await api.manualChores.update(entity)
     setEditing(false)
+    await api.manualChores.update(entity)
   }, [])
 
   return (

--- a/frontend/src/components/members/MemberItem.tsx
+++ b/frontend/src/components/members/MemberItem.tsx
@@ -17,8 +17,8 @@ export default function MemberItem (props: Props): ReactElement {
   const hideEditModal = useCallback(() => setEditing(false), [])
 
   const save = useCallback(async (entity: Member) => {
-    await api.members.update(entity)
     setEditing(false)
+    await api.members.update(entity)
   }, [])
 
   const itemName = (

--- a/frontend/src/components/scoreboards/ScoreboardItem.tsx
+++ b/frontend/src/components/scoreboards/ScoreboardItem.tsx
@@ -15,8 +15,8 @@ export default function ScoreboardItem (props: Props): ReactElement {
   const hideEditModal = useCallback(() => setEditing(false), [])
 
   const save = useCallback(async (entity: Scoreboard) => {
-    await api.scoreboards.update(entity)
     setEditing(false)
+    await api.scoreboards.update(entity)
   }, [])
 
   return (


### PR DESCRIPTION
Setting state (e.g. via setEditing) after component unmounting is an
error in React. This could happen because the WebSocket changed the
Redux store entity before the API call was done, meaning the entity item
would move around, and with it the modal got closed, before setEditing
was called. By explicitly closing the modal first and then calling the
API this is avoided.