### PR TITLE
feat(models,api): Add PeriodicChore model and routes

### DIFF
--- a/backend/api/api.ts
+++ b/backend/api/api.ts
@@ -6,10 +6,12 @@ import { createControllerRoute } from './controller-route'
 import { memberModel, memberValidator } from '../models/member'
 import { manualChoreModel, manualChoreValidator } from '../models/manual-chore'
 import { scoreboardModel, scoreboardValidator } from '../models/scoreboard'
+import { periodicChoreModel, periodicChoreValidator } from '../models/periodic-chore'
 
 const membersController = new Controller(memberModel, memberValidator, 'members')
 const manualChoresController = new Controller(manualChoreModel, manualChoreValidator, 'manual-chores')
 const scoreboardsController = new Controller(scoreboardModel, scoreboardValidator, 'scoreboards')
+const periodicChoresController = new Controller(periodicChoreModel, periodicChoreValidator, 'periodic-chores')
 
 export function createApiRouter (): Router {
   const router = Router()
@@ -19,6 +21,7 @@ export function createApiRouter (): Router {
   router.use('/members', createControllerRoute(membersController))
   router.use('/manual-chores', createControllerRoute(manualChoresController))
   router.use('/scoreboards', createControllerRoute(scoreboardsController))
+  router.use('/periodic-chores', createControllerRoute(periodicChoresController))
 
   // 404 fallback
   router.use(createHandler(() => {

--- a/backend/models/periodic-chore.ts
+++ b/backend/models/periodic-chore.ts
@@ -1,0 +1,54 @@
+import { model, Schema } from 'mongoose'
+import Joi from 'joi'
+import { idValidator } from './common'
+import { memberModel } from './member'
+
+export interface PeriodicChoreEntry {
+  memberId: typeof Schema.Types.ObjectId
+  date: string
+}
+
+export interface PeriodicChore {
+  name: string
+  period: number
+  entries: PeriodicChoreEntry[]
+}
+
+export const periodicChoreModel = model('PeriodicChore', new Schema<PeriodicChore>({
+  name: {
+    type: String,
+    required: true
+  },
+  period: {
+    type: Number,
+    required: true,
+    min: 1
+  },
+  entries: [
+    {
+      _id: false,
+      memberId: {
+        type: Schema.Types.ObjectId,
+        required: true,
+        ref: memberModel
+      },
+      date: {
+        type: String,
+        required: true
+      }
+    }
+  ]
+}))
+
+export const periodicChoreValidator = Joi.object({
+  _id: idValidator.required(),
+  name: Joi.string().trim().required(),
+  period: Joi.number().integer().min(1).required(),
+  entries: Joi.array().items(Joi.object({
+    memberId: idValidator.required(),
+    date: Joi.string().isoDate().required()
+  })).sort({
+    order: 'ascending',
+    by: 'date'
+  }).required()
+}).required()

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,11 +9,13 @@ import { useApiSliceBridge } from './api-slice-bridge'
 import { manualChoresActions } from './store/entities/manual-chores'
 import ConnectionModal from './components/ConnectionModal'
 import { scoreboardsActions } from './store/entities/scoreboards'
+import { periodicChoresActions } from './store/entities/periodic-chores'
 
 export default function App (): ReactElement {
   useApiSliceBridge('members', membersActions)
   useApiSliceBridge('manual-chores', manualChoresActions)
   useApiSliceBridge('scoreboards', scoreboardsActions)
+  useApiSliceBridge('periodic-chores', periodicChoresActions)
 
   return (
     <BrowserRouter>

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -2,6 +2,7 @@ import { CrudRoute } from './crud-route'
 import { Member } from '../store/entities/members'
 import { ManualChore } from '../store/entities/manual-chores'
 import { Scoreboard } from '../store/entities/scoreboards'
+import { PeriodicChore } from '../store/entities/periodic-chores'
 
 /**
  * A client for the REST API, mainly making accessible CRUD operations for all entity types.
@@ -10,6 +11,7 @@ export class Api {
   readonly members: CrudRoute<Member>
   readonly manualChores: CrudRoute<ManualChore>
   readonly scoreboards: CrudRoute<Scoreboard>
+  readonly periodicChores: CrudRoute<PeriodicChore>
 
   constructor (
     private readonly baseUrl: string
@@ -17,6 +19,7 @@ export class Api {
     this.members = new CrudRoute(baseUrl + 'members')
     this.manualChores = new CrudRoute(baseUrl + 'manual-chores')
     this.scoreboards = new CrudRoute(baseUrl + 'scoreboards')
+    this.periodicChores = new CrudRoute(baseUrl + 'periodic-chores')
   }
 }
 

--- a/frontend/src/editors/use-periodic-chore-editor.ts
+++ b/frontend/src/editors/use-periodic-chore-editor.ts
@@ -1,0 +1,19 @@
+import { Editor, useEditor } from './use-editor'
+import { PeriodicChore } from '../store/entities/periodic-chores'
+
+const DEFAULT: PeriodicChore = {
+  _id: '',
+  name: '',
+  period: 7,
+  entries: []
+}
+
+export function usePeriodicChoreEditor (value?: PeriodicChore): Editor<PeriodicChore> {
+  return useEditor({
+    value,
+    default: DEFAULT,
+    validate: entity => {
+      return entity.name.trim().length > 0 && Number.isSafeInteger(entity.period) && entity.period > 0
+    }
+  })
+}

--- a/frontend/src/store/entities/periodic-chores.ts
+++ b/frontend/src/store/entities/periodic-chores.ts
@@ -1,0 +1,22 @@
+import { Selector } from '@reduxjs/toolkit'
+import { createEntitySlice } from '../create-entity-slice'
+import { RootState } from '../store'
+import { Entity } from '../entity'
+
+export interface PeriodicChoreEntry {
+  readonly memberId: string
+  readonly date: string
+}
+
+export interface PeriodicChore extends Entity {
+  readonly name: string
+  readonly period: number
+  readonly entries: readonly PeriodicChoreEntry[]
+}
+
+const periodicChoresSlice = createEntitySlice<PeriodicChore>('periodic-chores')
+
+export const periodicChoresActions = periodicChoresSlice.actions
+export const selectPeriodicChores: Selector<RootState, PeriodicChore[]> = state => state.periodicChores
+
+export default periodicChoresSlice.reducer

--- a/frontend/src/store/store.ts
+++ b/frontend/src/store/store.ts
@@ -2,13 +2,15 @@ import { configureStore } from '@reduxjs/toolkit'
 import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux'
 import manualChores from './entities/manual-chores'
 import members from './entities/members'
+import periodicChores from './entities/periodic-chores'
 import scoreboards from './entities/scoreboards'
 
 export const store = configureStore({
   reducer: {
     members,
     manualChores,
-    scoreboards
+    scoreboards,
+    periodicChores
   }
 })
 


### PR DESCRIPTION
This type of chore can be used to set up a recurring chore with a fixed
interval (measured in days). Completion is recorded as a tuple of the
member who did the chore, and the respective date.