### PR TITLE
feat(components): Improve handling of invalid value in BasicDropdown

### DIFF
--- a/frontend/src/components/forms/BasicDropdown.tsx
+++ b/frontend/src/components/forms/BasicDropdown.tsx
@@ -1,36 +1,47 @@
 import './BasicDropdown.css'
-import { ChangeEventHandler, ReactElement, useMemo } from 'react'
+import { ChangeEventHandler, ReactElement, useCallback, useMemo } from 'react'
 import clsx from 'clsx'
+
+function useFormatter<V> (options: readonly V[], formatter: (item: V) => string): string[] {
+  return useMemo(() => options.map(formatter), [options, formatter])
+}
+
+function useChangeHandler<V> (options: readonly V[], onSelect?: (item: V) => void): ChangeEventHandler<HTMLSelectElement> {
+  return useCallback((event) => {
+    const index = parseInt(event.target.value, 10)
+    if (index >= 0 && index < options.length && onSelect != null) {
+      onSelect(options[index])
+    }
+  }, [onSelect, options])
+}
 
 interface Props<V> {
   disabled?: boolean
-  options: V[]
+  options: readonly V[]
   formatter: (item: V) => string
-  value?: V
+  value?: V | undefined
   onSelect?: (item: V) => void
   className?: string
 }
 
 export default function BasicDropdown<V> (props: Props<V>): ReactElement {
   /* eslint-disable react/prop-types */ // for some reason the linter complains here? maybe because of generics?
-  const valueIndex = props.value != null ? props.options.indexOf(props.value) : 0
 
-  const handleChange: ChangeEventHandler<HTMLSelectElement> = (event) => {
-    const index = parseInt(event.target.value, 10)
-    if (index >= 0 && index < props.options.length && props.onSelect != null) {
-      props.onSelect(props.options[index])
-    }
-  }
+  const valueIndex = useMemo(() => {
+    return props.value != null ? props.options.indexOf(props.value) : -1
+  }, [props.value, props.options])
 
-  const formattedOptions = useMemo(() => {
-    return props.options.map(props.formatter)
-  }, [props.options, props.formatter])
+  const invalidSelection = valueIndex < 0
+
+  const formattedOptions = useFormatter(props.options, props.formatter)
+  const handleChange = useChangeHandler(props.options, props.onSelect)
 
   return (
     <select className={clsx('BasicDropdown', props.className)}
             disabled={props.disabled}
             value={valueIndex}
             onChange={handleChange}>
+      {invalidSelection ? <option value={-1} /> : undefined}
       {formattedOptions.map((formattedOption, index) => (
         <option key={index} value={index}>{formattedOption}</option>
       ))}


### PR DESCRIPTION
If an unknown value is provided or value is missing entirely, an empty
option tag is now added to the beginning of the dropdown. This is better
than the status quo, which was to simply show the very first item, even
if it was not actually chosen, causing confusion.