### PR TITLE
feat(pages): Add rudimentary Calendar page for tracking chores

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { ReactElement } from 'react'
 import { BrowserRouter, Redirect, Route, Switch } from 'react-router-dom'
 import HomePage from './pages/HomePage'
+import CalendarPage from './pages/CalendarPage'
 import MembersPage from './pages/MembersPage'
 import CleaningPage from './pages/CleaningPage'
 import GarbageDisposalPage from './pages/GarbageDisposalPage'
@@ -23,6 +24,14 @@ export default function App (): ReactElement {
         {/* home page */}
         <Route exact path='/'>
           <HomePage />
+        </Route>
+
+        {/* calendar page */}
+        <Route exact path='/calendar'>
+          <CalendarPage />
+        </Route>
+        <Route exact path='/calendar/:choreId'>
+          <CalendarPage />
         </Route>
 
         {/* settings pages */}

--- a/frontend/src/components/NavigationBar.css
+++ b/frontend/src/components/NavigationBar.css
@@ -3,6 +3,7 @@
   left: 0;
   top: 0;
   height: 100vh;
+  z-index: 10;
 }
 
 .NavigationBar.active {
@@ -28,8 +29,8 @@
 
 .NavigationBar-sep {
   border: none;
-  height: 0;
-  margin: 16px 0;
+  height: 16px;
+  margin: 0;
 }
 
 /* toggle button */

--- a/frontend/src/components/NavigationBar.tsx
+++ b/frontend/src/components/NavigationBar.tsx
@@ -1,8 +1,8 @@
 import './NavigationBar.css'
-import { ReactElement, useCallback, useState } from 'react'
+import { Fragment, MouseEventHandler, ReactElement, useCallback, useState } from 'react'
 import { NavLink } from 'react-router-dom'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faBars, faBroom, faHome, faTimes, faTrashAlt, faUsers } from '@fortawesome/free-solid-svg-icons'
+import { faBars, faBroom, faCalendarAlt, faHome, faTimes, faTrashAlt, faUsers } from '@fortawesome/free-solid-svg-icons'
 import { IconDefinition } from '@fortawesome/fontawesome-svg-core'
 import { useTranslation } from 'react-i18next'
 import clsx from 'clsx'
@@ -11,18 +11,43 @@ interface NavItem {
   icon: IconDefinition
   label: string
   path: string
+  exact: boolean
 }
 
 const NAVIGATION: NavItem[][] = [
   [
-    { icon: faHome, label: 'home.title', path: '/' }
+    { icon: faHome, label: 'home.title', path: '/', exact: true }
   ],
   [
-    { icon: faUsers, label: 'members.title', path: '/members' },
-    { icon: faBroom, label: 'cleaning.title', path: '/cleaning' },
-    { icon: faTrashAlt, label: 'garbage.title', path: '/garbage' }
+    { icon: faCalendarAlt, label: 'calendar.title', path: '/calendar', exact: false }
+  ],
+  [
+    { icon: faUsers, label: 'members.title', path: '/members', exact: true },
+    { icon: faBroom, label: 'cleaning.title', path: '/cleaning', exact: true },
+    { icon: faTrashAlt, label: 'garbage.title', path: '/garbage', exact: true }
   ]
 ]
+
+function NavigationBarSeparator (): ReactElement {
+  return (
+    <hr className='NavigationBar-sep' />
+  )
+}
+
+function NavigationBarLink (props: { item: NavItem, onClick?: MouseEventHandler<HTMLElement> }): ReactElement {
+  const { t } = useTranslation()
+
+  const { item, onClick } = props
+
+  return (
+    <NavLink exact={item.exact} to={item.path} className='NavigationBar-link' onClick={onClick}>
+      <span className='NavigationBar-link-icon'>
+        <FontAwesomeIcon icon={item.icon} />
+      </span>
+      <span className='NavigationBar-link-label'>{t(item.label)}</span>
+    </NavLink>
+  )
+}
 
 export default function NavigationBar (): ReactElement {
   const { t } = useTranslation()
@@ -41,17 +66,12 @@ export default function NavigationBar (): ReactElement {
           <FontAwesomeIcon icon={active ? faTimes : faBars} />
         </button>
         {/* item groups */}
-        {NAVIGATION.flatMap((group, i) => [
-          <hr key={`${i}-sep`} className='NavigationBar-sep' />,
-          ...group.map((item, j) => (
-            <NavLink key={`${i}-${j}`} exact to={item.path} className='NavigationBar-link' onClick={close}>
-              <span className='NavigationBar-link-icon'>
-                <FontAwesomeIcon icon={item.icon} />
-              </span>
-              <span className='NavigationBar-link-label'>{t(item.label)}</span>
-            </NavLink>
-          ))
-        ])}
+        {NAVIGATION.map((group, i) => (
+          <Fragment key={i}>
+            <NavigationBarSeparator />
+            {group.map((item, j) => <NavigationBarLink key={j} item={item} onClick={close} />)}
+          </Fragment>
+        ))}
       </div>
     </div>
   )

--- a/frontend/src/components/calendar/Calendar.css
+++ b/frontend/src/components/calendar/Calendar.css
@@ -1,0 +1,11 @@
+.Calendar-item {
+  margin: 16px 0;
+  padding: 16px 12px;
+  background: #fff;
+  border-radius: 2px;
+  box-shadow: 0 4px 12px 0 rgba(0, 0, 0, 0.1);
+}
+
+.Calendar-item-member {
+  font-size: 20px;
+}

--- a/frontend/src/components/calendar/Calendar.tsx
+++ b/frontend/src/components/calendar/Calendar.tsx
@@ -1,0 +1,54 @@
+import './Calendar.css'
+import { PeriodicChoreEntry } from '../../store/entities/periodic-chores'
+import { useAppSelector } from '../../store/store'
+import { selectMembers } from '../../store/entities/members'
+import { useMemo } from 'react'
+import Empty from '../Empty'
+import { useTranslation } from 'react-i18next'
+
+/**
+ * Behaves like Array.prototype.map, but starts at the right and moves backwards through the array.
+ * This is a more performant version of calling map() followed by reverse().
+ *
+ * @param array The array to map.
+ * @param callbackFn The mapping function.
+ * @returns The mapped and reversed array.
+ */
+function mapRight<T, U> (array: readonly T[], callbackFn: (value: T, index: number) => U): U[] {
+  return array.map((value, index) => {
+    const actualIndex = array.length - 1 - index
+    return callbackFn(array[actualIndex], actualIndex)
+  })
+}
+
+function formatDate (date: string): string {
+  return date.length >= 10 ? date.substring(0, 10) : '???'
+}
+
+interface Props {
+  items: readonly PeriodicChoreEntry[]
+}
+
+export default function Calendar (props: Props): JSX.Element {
+  const { t } = useTranslation()
+
+  const members = useAppSelector(selectMembers)
+  const membersMap = useMemo(() => {
+    return new Map(members.map(item => [item._id, item]))
+  }, [members])
+
+  if (props.items.length === 0) {
+    return <Empty message={t('calendar.empty.noItems')} />
+  }
+
+  return (
+    <div className='Calendar'>
+      {mapRight(props.items, (item, i) => (
+        <div key={i} className='Calendar-item'>
+          <div className='Calendar-item-date'>{formatDate(item.date)}</div>
+          <div className='Calendar-item-member'>{membersMap.get(item.memberId)?.name ?? '--'}</div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/components/home/PeriodicChoreBox.css
+++ b/frontend/src/components/home/PeriodicChoreBox.css
@@ -4,6 +4,23 @@
 
 .PeriodicChoreBox-title {
   font-size: 24px;
+  white-space: nowrap;
+}
+
+.PeriodicChoreBox-calendar {
+  display: inline-block;
+  margin-left: 16px;
+  padding: 0 0.25em;
+  font: inherit;
+  color: inherit;
+  opacity: 0.7;
+}
+
+.PeriodicChoreBox-calendar:focus,
+.PeriodicChoreBox-calendar:hover {
+  opacity: 1;
+  outline: 2px solid #bbb;
+  outline-offset: 2px;
 }
 
 .PeriodicChoreBox-detail {

--- a/frontend/src/components/home/PeriodicChoreBox.tsx
+++ b/frontend/src/components/home/PeriodicChoreBox.tsx
@@ -8,6 +8,9 @@ import { useTranslation } from 'react-i18next'
 import BasicButton from '../forms/BasicButton'
 import api from '../../api/api'
 import { SelectMemberModal } from './SelectMemberModal'
+import { Link } from 'react-router-dom'
+import { faCalendarAlt } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 function useRecentlyCompletedString (entries: readonly PeriodicChoreEntry[]): string {
   const last = entries.length > 0 ? entries[entries.length - 1] : undefined
@@ -57,6 +60,9 @@ export default function PeriodicChoreBox (props: Props): ReactElement {
     <ChoreBox className='PeriodicChoreBox'>
       <div className='PeriodicChoreBox-title'>
         {props.chore.name}
+        <Link to={`/calendar/${props.chore._id}`} className='PeriodicChoreBox-calendar'>
+          <FontAwesomeIcon icon={faCalendarAlt} />
+        </Link>
       </div>
       <div className='PeriodicChoreBox-detail'>
         {t('home.chores.last')}<br />

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -22,6 +22,14 @@
     },
     "selectMember": "Wer hat die Aufgabe erledigt?"
   },
+  "calendar": {
+    "title": "Kalender",
+    "empty": {
+      "noChores": "Keine Dienste mit Kalender sind konfiguriert.",
+      "unselected": "Wähle einen Dienst aus, um den Kalender anzuzeigen.",
+      "noItems": "Der Kalender ist noch leer."
+    }
+  },
   "members": {
     "title": "Mitbewohner",
     "empty": "Es sind aktuell keine Mitbewohner hinzugefügt.",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -22,6 +22,14 @@
     },
     "selectMember": "Who completed the task?"
   },
+  "calendar": {
+    "title": "Calendar",
+    "empty": {
+      "noChores": "No chores with calendar are configured.",
+      "unselected": "Select a chore above to show its calendar.",
+      "noItems": "The calendar for this is still empty."
+    }
+  },
   "members": {
     "title": "Members",
     "empty": "There are no current members added.",

--- a/frontend/src/pages/CalendarPage.tsx
+++ b/frontend/src/pages/CalendarPage.tsx
@@ -1,0 +1,50 @@
+import { ReactElement, useCallback } from 'react'
+import NavigationBarLayout from '../layouts/NavigationBarLayout'
+import { useHistory, useParams } from 'react-router-dom'
+import { useAppSelector } from '../store/store'
+import { PeriodicChore, selectPeriodicChores } from '../store/entities/periodic-chores'
+import { useEntityById } from '../util/use-entity-by-id'
+import Title from '../components/Title'
+import { useTranslation } from 'react-i18next'
+import Calendar from '../components/calendar/Calendar'
+import BasicDropdown from '../components/forms/BasicDropdown'
+import Empty from '../components/Empty'
+
+function formatChore (chore: PeriodicChore): string {
+  return chore.name
+}
+
+interface Params {
+  choreId?: string
+}
+
+export default function CalendarPage (): ReactElement {
+  const { t } = useTranslation()
+
+  const params = useParams<Params>()
+
+  const periodicChores = useAppSelector(selectPeriodicChores)
+  const chore = useEntityById(selectPeriodicChores, params.choreId)
+
+  const history = useHistory()
+  const handleSelect = useCallback((item: PeriodicChore) => {
+    history.push(`/calendar/${item._id}`)
+  }, [history])
+
+  return (
+    <NavigationBarLayout centered>
+      <Title title={t('calendar.title')}>
+        <BasicDropdown
+          disabled={periodicChores.length === 0}
+          options={periodicChores}
+          formatter={formatChore}
+          value={chore}
+          onSelect={handleSelect}
+        />
+      </Title>
+      {periodicChores.length === 0 ? <Empty message={t('calendar.empty.noChores')} /> : undefined}
+      {periodicChores.length > 0 && chore == null ? <Empty message={t('calendar.empty.unselected')} /> : undefined}
+      {chore != null ? <Calendar items={chore.entries} /> : undefined}
+    </NavigationBarLayout>
+  )
+}


### PR DESCRIPTION
The page can be opened by clicking an icon in the PeriodicChoreBox, or
by navigating directly via the NavigationBar and selecting a chore from
the dropdown. Then, the chore entries are shown in a list format.