### PR TITLE
refactor(components): Split off chore-specific functions from Calendar

### DIFF
--- a/frontend/src/components/calendar/Calendar.css
+++ b/frontend/src/components/calendar/Calendar.css
@@ -63,24 +63,3 @@
 .Calendar-td.inactive {
   background: rgba(0, 0, 0, 0.02);
 }
-
-.Calendar-entry {
-  display: block;
-  width: 100%;
-  margin: 0;
-  padding: 4px;
-  font: inherit;
-  font-weight: bold;
-  background: #eee;
-  border: 2px solid #fff;
-  border-radius: 4px;
-  cursor: pointer;
-  outline: none;
-  text-shadow: 0 0 2px #fff;
-}
-
-.Calendar-entry:focus,
-.Calendar-entry:hover {
-  border-color: #666;
-  box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.4);
-}

--- a/frontend/src/components/calendar/PeriodicChoreCalendar.css
+++ b/frontend/src/components/calendar/PeriodicChoreCalendar.css
@@ -1,0 +1,20 @@
+.PeriodicChoreCalendarEntry {
+  display: block;
+  width: 100%;
+  margin: 0;
+  padding: 4px;
+  font: inherit;
+  font-weight: bold;
+  background: #eee;
+  border: 2px solid #fff;
+  border-radius: 4px;
+  cursor: pointer;
+  outline: none;
+  text-shadow: 0 0 2px #fff;
+}
+
+.PeriodicChoreCalendarEntry:focus,
+.PeriodicChoreCalendarEntry:hover {
+  border-color: #666;
+  box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.4);
+}

--- a/frontend/src/components/calendar/PeriodicChoreCalendar.tsx
+++ b/frontend/src/components/calendar/PeriodicChoreCalendar.tsx
@@ -1,0 +1,73 @@
+import './PeriodicChoreCalendar.css'
+import { ReactElement, useCallback, useMemo } from 'react'
+import { PeriodicChoreEntry } from '../../store/entities/periodic-chores'
+import Calendar, { CellRenderFn } from './Calendar'
+import { DateTime } from 'luxon'
+import { useEntityById } from '../../util/use-entity-by-id'
+import { selectMembers } from '../../store/entities/members'
+
+type EntryMap = Map<string, readonly PeriodicChoreEntry[]>
+
+/**
+ * Convert a date-time into an ISO date string (yyyy-MM-dd).
+ *
+ * @param date The date-time.
+ * @returns The formatted string.
+ */
+function formatDate (date: DateTime | string): string {
+  const dateTime = typeof date === 'string'
+    ? DateTime.fromISO(date, { zone: 'utc' })
+    : date
+  return dateTime.toLocal().toFormat('yyyy-MM-dd')
+}
+
+/**
+ * Transform the given array of entries into a map-lookup format,
+ * where ISO date strings (yyyy-MM-dd) are keys, and their associated values are the respective
+ * array of entries for that date.
+ *
+ * @param items The items array.
+ * @returns The resulting map for lookup of entries on a given date.
+ */
+function useEntryMap (items: readonly PeriodicChoreEntry[]): EntryMap {
+  return useMemo(() => {
+    const map = new Map<string, PeriodicChoreEntry[]>()
+    for (const item of items) {
+      const day = formatDate(item.date)
+      const array = map.get(day) ?? []
+      array.push(item)
+      map.set(day, array)
+    }
+    return map
+  }, [items])
+}
+
+function PeriodicChoreCalendarEntry (props: { entry: PeriodicChoreEntry }): ReactElement {
+  const member = useEntityById(selectMembers, props.entry.memberId)
+
+  return (
+    <button className='PeriodicChoreCalendarEntry' style={{ backgroundColor: member?.color }}>
+      {member?.name ?? '???'}
+    </button>
+  )
+}
+
+interface Props {
+  entries: readonly PeriodicChoreEntry[]
+}
+
+export default function PeriodicChoreCalendar (props: Props): ReactElement {
+  const map = useEntryMap(props.entries)
+
+  const renderCell: CellRenderFn = useCallback(date => {
+    const entries = map.get(formatDate(date))
+    if (entries == null) {
+      return undefined
+    }
+    return entries.map((entry, i) => <PeriodicChoreCalendarEntry key={i} entry={entry} />)
+  }, [map])
+
+  return (
+    <Calendar renderCell={renderCell} />
+  )
+}

--- a/frontend/src/pages/CalendarPage.tsx
+++ b/frontend/src/pages/CalendarPage.tsx
@@ -6,7 +6,7 @@ import { PeriodicChore, selectPeriodicChores } from '../store/entities/periodic-
 import { useEntityById } from '../util/use-entity-by-id'
 import Title from '../components/Title'
 import { useTranslation } from 'react-i18next'
-import Calendar from '../components/calendar/Calendar'
+import PeriodicChoreCalendar from '../components/calendar/PeriodicChoreCalendar'
 import BasicDropdown from '../components/forms/BasicDropdown'
 import Empty from '../components/Empty'
 
@@ -44,7 +44,7 @@ export default function CalendarPage (): ReactElement {
       </Title>
       {periodicChores.length === 0 ? <Empty message={t('calendar.empty.noChores')} /> : undefined}
       {periodicChores.length > 0 && chore == null ? <Empty message={t('calendar.empty.unselected')} /> : undefined}
-      {chore != null ? <Calendar items={chore.entries} /> : undefined}
+      {chore != null ? <PeriodicChoreCalendar entries={chore.entries} /> : undefined}
     </NavigationBarLayout>
   )
 }


### PR DESCRIPTION
This change makes the Calendar fully generic and moves everything
related to displaying chores into a PeriodicChoreCalendar that wraps it,
using a render function for cell content.