### PR TITLE
fix(components): Fix warning about missing key in Title children

### DIFF
--- a/frontend/src/components/Title.tsx
+++ b/frontend/src/components/Title.tsx
@@ -14,12 +14,10 @@ export default function Title (props: PropsWithChildren<Props>): ReactElement {
 
   return (
     <div className='Title'>
+      {/* <h1> or <h2>, depending on props */}
       {createElement(props.minor === true ? 'h2' : 'h1', {
         className: 'Title-h'
-      }, [
-        iconElement,
-        props.title
-      ])}
+      }, iconElement, props.title)}
       {props.children}
     </div>
   )


### PR DESCRIPTION
By removing the outer array, the children are added directly and React
no longer complains that they need a key prop.