### PR TITLE
fix(components): Allow explicit undefined in BasicDropdown options

### DIFF
--- a/frontend/src/components/chores/EditManualChoreModal.tsx
+++ b/frontend/src/components/chores/EditManualChoreModal.tsx
@@ -11,7 +11,7 @@ import { useEntityById } from '../../util/use-entity-by-id'
 import { useManualChoreEditor } from '../../editors/use-manual-chore-editor'
 import { useParametrized } from '../../util/use-parametrized'
 
-function useScoreboardFormatter (): (item: Scoreboard | null) => string {
+function useScoreboardFormatter (): (item: Scoreboard | undefined) => string {
   const { t } = useTranslation()
   return item => item == null ? t('noneOption') : item.name
 }
@@ -34,7 +34,7 @@ export default function EditManualChoreModal (props: Props): ReactElement {
 
   const save = useParametrized(props.onSave, editor.value)
 
-  const scoreboardOptions = useMemo(() => [null, ...scoreboards], [scoreboards])
+  const scoreboardOptions = useMemo(() => [undefined, ...scoreboards], [scoreboards])
   const scoreboardFormatter = useScoreboardFormatter()
   const scoreboardValue = useEntityById(selectScoreboards, editor.value.scoreboardId)
 

--- a/frontend/src/components/forms/BasicDropdown.tsx
+++ b/frontend/src/components/forms/BasicDropdown.tsx
@@ -28,9 +28,10 @@ export default function BasicDropdown<V> (props: Props<V>): ReactElement {
   /* eslint-disable react/prop-types */ // for some reason the linter complains here? maybe because of generics?
 
   const valueIndex = useMemo(() => {
-    return props.value != null ? props.options.indexOf(props.value) : -1
+    // @ts-expect-error because props.value can be undefined, but props.options cannot contain undefined
+    // (this component is a lot more useful if value can be undefined, so we need to allow this, unfortunately)
+    return props.options.indexOf(props.value)
   }, [props.value, props.options])
-
   const invalidSelection = valueIndex < 0
 
   const formattedOptions = useFormatter(props.options, props.formatter)


### PR DESCRIPTION
A value of undefined can now be selected and will show the formatted
string, instead of resulting in an "invalid selection option" to be
created.