### PR TITLE
feat(api): Let DELETE via Controller cascade into dependent models

### DIFF
--- a/backend/api/api.ts
+++ b/backend/api/api.ts
@@ -4,14 +4,20 @@ import { NotFoundError } from './errors'
 import { Controller } from '../controllers/controller'
 import { createControllerRoute } from './controller-route'
 import { memberModel, memberValidator } from '../models/member'
-import { manualChoreModel, manualChoreValidator } from '../models/manual-chore'
-import { scoreboardModel, scoreboardValidator } from '../models/scoreboard'
-import { periodicChoreModel, periodicChoreValidator } from '../models/periodic-chore'
+import { PeriodicChoreController } from '../controllers/periodic-chore-controller'
+import { ManualChoreController } from '../controllers/manual-chore-controller'
+import { ScoreboardController } from '../controllers/scoreboard-controller'
 
 const membersController = new Controller(memberModel, memberValidator, 'members')
-const manualChoresController = new Controller(manualChoreModel, manualChoreValidator, 'manual-chores')
-const scoreboardsController = new Controller(scoreboardModel, scoreboardValidator, 'scoreboards')
-const periodicChoresController = new Controller(periodicChoreModel, periodicChoreValidator, 'periodic-chores')
+const scoreboardsController = new ScoreboardController('scoreboards', {
+  member: membersController
+})
+const manualChoresController = new ManualChoreController('manual-chores', {
+  scoreboard: scoreboardsController
+})
+const periodicChoresController = new PeriodicChoreController('periodic-chores', {
+  member: membersController
+})
 
 export function createApiRouter (): Router {
   const router = Router()

--- a/backend/controllers/manual-chore-controller.ts
+++ b/backend/controllers/manual-chore-controller.ts
@@ -1,0 +1,27 @@
+import { Controller } from './controller'
+import { Document, QueryCursor } from 'mongoose'
+import { broadcast } from '../websocket/events'
+import { ManualChore, manualChoreModel, manualChoreValidator } from '../models/manual-chore'
+import { Scoreboard } from '../models/scoreboard'
+
+export interface ManualChoreDependencies {
+  scoreboard: Controller<Scoreboard>
+}
+
+export class ManualChoreController extends Controller<ManualChore> {
+  constructor (broadcastName: string, dependencies: ManualChoreDependencies) {
+    super(manualChoreModel, manualChoreValidator, broadcastName)
+
+    // unset scoreboards when they are deleted
+    dependencies.scoreboard.on('deleted', async (other) => {
+      const cursor: QueryCursor<Document<any, any, ManualChore>> = manualChoreModel.find({
+        scoreboardId: other._id
+      }).cursor()
+      await cursor.eachAsync(async (item) => {
+        item.set({ scoreboardId: null })
+        const saved = await item.save()
+        broadcast('update/' + broadcastName, saved)
+      })
+    })
+  }
+}

--- a/backend/controllers/periodic-chore-controller.ts
+++ b/backend/controllers/periodic-chore-controller.ts
@@ -1,0 +1,33 @@
+import { Controller } from './controller'
+import { PeriodicChore, periodicChoreModel, periodicChoreValidator } from '../models/periodic-chore'
+import { Member } from '../models/member'
+import { Document, QueryCursor } from 'mongoose'
+import { broadcast } from '../websocket/events'
+
+export interface PeriodicChoreDependencies {
+  member: Controller<Member>
+}
+
+export class PeriodicChoreController extends Controller<PeriodicChore> {
+  constructor (broadcastName: string, dependencies: PeriodicChoreDependencies) {
+    super(periodicChoreModel, periodicChoreValidator, broadcastName)
+
+    // remove entries for members when they are deleted
+    dependencies.member.on('deleted', async (other) => {
+      const cursor: QueryCursor<Document<any, any, PeriodicChore>> = periodicChoreModel.find({
+        'entries.memberId': other._id
+      }).cursor()
+      await cursor.eachAsync(async (item) => {
+        await item.updateOne({
+          $pull: {
+            entries: {
+              memberId: other._id
+            }
+          }
+        })
+        const updated = await periodicChoreModel.findById(item._id)
+        broadcast('update/' + broadcastName, updated)
+      })
+    })
+  }
+}

--- a/backend/controllers/scoreboard-controller.ts
+++ b/backend/controllers/scoreboard-controller.ts
@@ -1,0 +1,33 @@
+import { Controller } from './controller'
+import { Member } from '../models/member'
+import { Document, QueryCursor } from 'mongoose'
+import { broadcast } from '../websocket/events'
+import { Scoreboard, scoreboardModel, scoreboardValidator } from '../models/scoreboard'
+
+export interface ScoreboardDependencies {
+  member: Controller<Member>
+}
+
+export class ScoreboardController extends Controller<Scoreboard> {
+  constructor (broadcastName: string, dependencies: ScoreboardDependencies) {
+    super(scoreboardModel, scoreboardValidator, broadcastName)
+
+    // remove scores for members when they are deleted
+    dependencies.member.on('deleted', async (other) => {
+      const cursor: QueryCursor<Document<any, any, Scoreboard>> = scoreboardModel.find({
+        'scores.memberId': other._id
+      }).cursor()
+      await cursor.eachAsync(async (item) => {
+        await item.updateOne({
+          $pull: {
+            scores: {
+              memberId: other._id
+            }
+          }
+        })
+        const updated = await scoreboardModel.findById(item._id)
+        broadcast('update/' + broadcastName, updated)
+      })
+    })
+  }
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "joi": "^17.4.2",
-    "mongoose": "^6.0.6"
+    "mongoose": "^6.0.6",
+    "tiny-typed-emitter": "^2.1.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,8 @@
       "version": "0.0.0",
       "dependencies": {
         "joi": "^17.4.2",
-        "mongoose": "^6.0.6"
+        "mongoose": "^6.0.6",
+        "tiny-typed-emitter": "^2.1.0"
       },
       "devDependencies": {
         "@types/express": "^4.17.13",
@@ -21878,6 +21879,11 @@
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
       "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw=="
     },
+    "node_modules/tiny-typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA=="
+    },
     "node_modules/tiny-warning": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
@@ -28817,6 +28823,7 @@
         "joi": "^17.4.2",
         "mongoose": "^6.0.6",
         "rimraf": "^3.0.2",
+        "tiny-typed-emitter": "*",
         "typescript": "^4.4.3"
       }
     },
@@ -32692,7 +32699,7 @@
         "i18next-browser-languagedetector": "^6.1.2",
         "luxon": "^2.0.2",
         "react": "^17.0.2",
-        "react-circular-progressbar": "*",
+        "react-circular-progressbar": "^2.0.4",
         "react-dom": "^17.0.2",
         "react-i18next": "^11.12.0",
         "react-redux": "^7.2.5",
@@ -41934,6 +41941,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
       "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw=="
+    },
+    "tiny-typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA=="
     },
     "tiny-warning": {
       "version": "1.0.3",


### PR DESCRIPTION
When an entity such as a Member is deleted via the controller, other
controllers can react to ensure there are no unresolvable references
(e.g. by deleting Scoreboard scores belonging to the removed Member).