### PR TITLE
feat(components): Implement rudimentary "next due" in PeriodicChoreBox

### DIFF
--- a/frontend/src/components/home/PeriodicChoreBox.tsx
+++ b/frontend/src/components/home/PeriodicChoreBox.tsx
@@ -13,6 +13,7 @@ import { faCalendarAlt } from '@fortawesome/free-solid-svg-icons'
 import { DateTime } from 'luxon'
 import UrgencyIndicator from './UrgencyIndicator'
 import Icon from '../Icon'
+import { useAppSelector } from '../../store/store'
 
 /**
  * After this much progress has been made towards the next due-date, show the chore as being urgent.
@@ -46,6 +47,24 @@ function useRecentlyCompletedString (chore: PeriodicChore): string {
 }
 
 /**
+ * For a give chore, determine the number of days since last completion.
+ *
+ * @param chore The chore.
+ * @returns The number of days that have passed.
+ */
+function useDaysSinceLast (chore: PeriodicChore): number | undefined {
+  const last = useMostRecent(chore.entries)
+
+  return useMemo(() => {
+    if (last == null) {
+      return undefined
+    }
+    const lastDate = DateTime.fromISO(last.date, { zone: 'utc' })
+    return Math.round(DateTime.now().diff(lastDate).as('days'))
+  }, [last])
+}
+
+/**
  * For a given chore, compute the urgency value (number between 0 and 1), where 0 indicates minimal urgency
  * (i.e. the chore was very recently completed) and 1 indicates maximum urgency (the chore is due today or is
  * already past the due date).
@@ -54,16 +73,51 @@ function useRecentlyCompletedString (chore: PeriodicChore): string {
  * @returns The urgency value.
  */
 function useUrgency (chore: PeriodicChore): number {
-  const last = useMostRecent(chore.entries)
+  const diffDays = useDaysSinceLast(chore)
 
   return useMemo(() => {
-    if (last == null) {
-      return 0
+    return diffDays != null
+      ? Math.max(0, Math.min(1, diffDays / chore.period))
+      : 0
+  }, [diffDays, chore.period])
+}
+
+/**
+ * For a given chore, determine the string to show for the "next up" property.
+ * This string includes the member name and if possible, the remaining days for that member to complete the chore.
+ *
+ * @param chore The chore.
+ * @returns A string describing the upcoming due date.
+ */
+function usePlannedEntry (chore: PeriodicChore): string {
+  const { t } = useTranslation()
+
+  const diffDays = useDaysSinceLast(chore)
+
+  const members = useAppSelector(selectMembers)
+  const activeMembers = useMemo(() => members.filter(item => item.active), [members])
+
+  return useMemo(() => {
+    // no active members means nobody can complete the chore
+    if (activeMembers.length === 0) {
+      return '--'
     }
-    const lastDate = DateTime.fromISO(last.date, { zone: 'utc' })
-    const diffDays = Math.round(DateTime.now().diff(lastDate).as('days'))
-    return Math.max(0, Math.min(1, diffDays / chore.period))
-  }, [last, chore.period])
+    // move backwards through time, eliminating members until there is at most one left
+    const remaining = activeMembers.slice(0)
+    for (let i = chore.entries.length - 1; i >= 0 && remaining.length > 1; --i) {
+      const index = remaining.findIndex(item => item._id === chore.entries[i].memberId)
+      if (index >= 0) {
+        remaining.splice(index, 1)
+      }
+    }
+    // choose the remaining member (if there are multiple, choose the one first in the alphabet)
+    const nextMember = remaining.sort((a, b) => a.name.localeCompare(b.name))[0]
+    if (diffDays != null) {
+      const daysRemaining = Math.max(0, chore.period - diffDays)
+      return t('home.chores.nextFormatDays', { name: nextMember.name, days: daysRemaining })
+    }
+    return t('home.chores.nextFormat', { name: nextMember.name })
+  }, [t, chore, activeMembers, diffDays])
 }
 
 /**
@@ -94,6 +148,7 @@ export default function PeriodicChoreBox (props: Props): ReactElement {
 
   const urgency = useUrgency(props.chore)
   const recentlyCompleted = useRecentlyCompletedString(props.chore)
+  const planned = usePlannedEntry(props.chore)
 
   const [isSelectingMember, setSelectingMember] = useState(false)
 
@@ -119,6 +174,10 @@ export default function PeriodicChoreBox (props: Props): ReactElement {
       <div className='PeriodicChoreBox-detail'>
         {t('home.chores.last')}<br />
         {recentlyCompleted}
+      </div>
+      <div className='PeriodicChoreBox-detail'>
+        {t('home.chores.next')}<br />
+        {planned}
       </div>
       <div>
         <BasicButton onClick={startMarkDone}>

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -14,6 +14,9 @@
     "empty": "Nichts anzuzeigen. Wenn eine Aufgabe erstellt wird, wird sie hier erscheinen.",
     "chores": {
       "last": "Zuletzt erledigt",
+      "next": "Nächster Dienst",
+      "nextFormat": "{{name}}",
+      "nextFormatDays": "{{name}} (noch {{days}} Tag(e))",
       "markDue": "Als fällig markieren",
       "markDone": "Dienst eintragen"
     },

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -14,6 +14,9 @@
     "empty": "Nothing to show. If a task is configured, it will show up here.",
     "chores": {
       "last": "Recently completed",
+      "next": "Next up",
+      "nextFormat": "{{name}}",
+      "nextFormatDays": "{{name}} ({{days}} day(s) left)",
       "markDue": "Mark due",
       "markDone": "Mark as done"
     },


### PR DESCRIPTION
The next due date is computed client-side based on the most recent
entries. The algorithm is neither very efficient nor customizable, but
it should be better than nothing. It displays the member name and number
of remaining days.