### PR TITLE
refactor(models): Use EnforceDocument type and fix ObjectId typing

### DIFF
--- a/backend/controllers/manual-chore-controller.ts
+++ b/backend/controllers/manual-chore-controller.ts
@@ -1,5 +1,5 @@
 import { Controller } from './controller'
-import { Document, QueryCursor } from 'mongoose'
+import { EnforceDocument, QueryCursor } from 'mongoose'
 import { ManualChore, manualChoreModel, manualChoreValidator } from '../models/manual-chore'
 import { Scoreboard } from '../models/scoreboard'
 
@@ -13,13 +13,13 @@ export class ManualChoreController extends Controller<ManualChore> {
 
     // unset scoreboards when they are deleted
     dependencies.scoreboard.on('deleted', async (other) => {
-      const cursor: QueryCursor<Document<any, any, ManualChore>> = manualChoreModel.find({
+      const cursor: QueryCursor<EnforceDocument<ManualChore, {}>> = manualChoreModel.find({
         scoreboardId: other._id
       }).cursor()
       await cursor.eachAsync(async (item) => {
-        item.set({ scoreboardId: null })
-        const saved = await item.save()
-        this.emit('updated', saved)
+        item.scoreboardId = null
+        await item.save()
+        this.emit('updated', item)
       })
     })
   }

--- a/backend/controllers/periodic-chore-controller.ts
+++ b/backend/controllers/periodic-chore-controller.ts
@@ -1,7 +1,7 @@
 import { Controller } from './controller'
 import { PeriodicChore, periodicChoreModel, periodicChoreValidator } from '../models/periodic-chore'
 import { Member } from '../models/member'
-import { Document, QueryCursor } from 'mongoose'
+import { EnforceDocument, QueryCursor } from 'mongoose'
 
 export interface PeriodicChoreDependencies {
   member: Controller<Member>
@@ -13,7 +13,7 @@ export class PeriodicChoreController extends Controller<PeriodicChore> {
 
     // remove entries for members when they are deleted
     dependencies.member.on('deleted', async (other) => {
-      const cursor: QueryCursor<Document<any, any, PeriodicChore>> = periodicChoreModel.find({
+      const cursor: QueryCursor<EnforceDocument<PeriodicChore, {}>> = periodicChoreModel.find({
         'entries.memberId': other._id
       }).cursor()
       await cursor.eachAsync(async (item) => {

--- a/backend/controllers/scoreboard-controller.ts
+++ b/backend/controllers/scoreboard-controller.ts
@@ -1,6 +1,6 @@
 import { Controller } from './controller'
 import { Member } from '../models/member'
-import { Document, QueryCursor } from 'mongoose'
+import { EnforceDocument, QueryCursor } from 'mongoose'
 import { Scoreboard, scoreboardModel, scoreboardValidator } from '../models/scoreboard'
 
 export interface ScoreboardDependencies {
@@ -13,7 +13,7 @@ export class ScoreboardController extends Controller<Scoreboard> {
 
     // remove scores for members when they are deleted
     dependencies.member.on('deleted', async (other) => {
-      const cursor: QueryCursor<Document<any, any, Scoreboard>> = scoreboardModel.find({
+      const cursor: QueryCursor<EnforceDocument<Scoreboard, {}>> = scoreboardModel.find({
         'scores.memberId': other._id
       }).cursor()
       await cursor.eachAsync(async (item) => {

--- a/backend/models/manual-chore.ts
+++ b/backend/models/manual-chore.ts
@@ -1,4 +1,4 @@
-import { model, Schema } from 'mongoose'
+import { model, Schema, Types } from 'mongoose'
 import Joi from 'joi'
 import { scoreboardModel } from './scoreboard'
 import { idValidator } from './common'
@@ -6,7 +6,7 @@ import { idValidator } from './common'
 export interface ManualChore {
   name: string
   dueSince: number
-  scoreboardId: typeof Schema.Types.ObjectId
+  scoreboardId: Types.ObjectId | null
 }
 
 export const manualChoreModel = model('ManualChore', new Schema<ManualChore>({

--- a/backend/models/periodic-chore.ts
+++ b/backend/models/periodic-chore.ts
@@ -1,10 +1,10 @@
-import { model, Schema } from 'mongoose'
+import { model, Schema, Types } from 'mongoose'
 import Joi from 'joi'
 import { idValidator } from './common'
 import { memberModel } from './member'
 
 export interface PeriodicChoreEntry {
-  memberId: typeof Schema.Types.ObjectId
+  memberId: Types.ObjectId
   date: string
 }
 

--- a/backend/models/scoreboard.ts
+++ b/backend/models/scoreboard.ts
@@ -1,10 +1,10 @@
-import { model, Schema } from 'mongoose'
+import { model, Schema, Types } from 'mongoose'
 import { memberModel } from './member'
 import Joi from 'joi'
 import { idValidator } from './common'
 
 export interface ScoreboardEntry {
-  memberId: typeof Schema.Types.ObjectId
+  memberId: Types.ObjectId
   offset: number
   score: number
 }


### PR DESCRIPTION
By using EnforceDocument instead of Document, our own interface's
properties are also available for access (since EnforceDocument creates
a union of Document and the custom interface). ObjectId typing needed
to be adapted as well so that we can use .equals() on ids if needed.