### PR TITLE
feat(models,api): Add Group model and routes

### DIFF
--- a/backend/controllers/member-controller.ts
+++ b/backend/controllers/member-controller.ts
@@ -1,0 +1,26 @@
+import { Controller } from './controller'
+import { Member, memberModel, memberValidator } from '../models/member'
+import { EnforceDocument, QueryCursor } from 'mongoose'
+import { Group } from '../models/group'
+
+export interface MemberDependencies {
+  group: Controller<Group>
+}
+
+export class MemberController extends Controller<Member> {
+  constructor (dependencies: MemberDependencies) {
+    super(memberModel, memberValidator)
+
+    // remove groups for members when they are deleted
+    dependencies.group.on('deleted', async (other) => {
+      const cursor: QueryCursor<EnforceDocument<Member, {}>> = memberModel.find({
+        groups: other._id
+      }).cursor()
+      await cursor.eachAsync(async (item) => {
+        item.groups = item.groups.filter(id => !id.equals(other._id))
+        const updated = await memberModel.findById(item._id)
+        this.emit('updated', updated)
+      })
+    })
+  }
+}

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -1,15 +1,19 @@
 import mongoose from 'mongoose'
 import { Environment } from './environment'
 import { Controller } from './controllers/controller'
-import { memberModel, memberValidator } from './models/member'
+import { groupModel, groupValidator } from './models/group'
 import { ScoreboardController } from './controllers/scoreboard-controller'
 import { ManualChoreController } from './controllers/manual-chore-controller'
 import { PeriodicChoreController } from './controllers/periodic-chore-controller'
 
 import { createRouter, createErrorHandler } from './api/api'
 import { handler as wsHandler } from './websocket/handler'
+import { MemberController } from './controllers/member-controller'
 
-const membersController = new Controller(memberModel, memberValidator)
+const groupsController = new Controller(groupModel, groupValidator)
+const membersController = new MemberController({
+  group: groupsController
+})
 const scoreboardsController = new ScoreboardController({
   member: membersController
 })
@@ -21,6 +25,7 @@ const periodicChoresController = new PeriodicChoreController({
 })
 
 const controllers: Record<string, Controller<unknown>> = {
+  groups: groupsController,
   members: membersController,
   scoreboards: scoreboardsController,
   'manual-chores': manualChoresController,

--- a/backend/models/group.ts
+++ b/backend/models/group.ts
@@ -1,0 +1,19 @@
+import { model, Schema } from 'mongoose'
+import Joi from 'joi'
+import { idValidator } from './common'
+
+export interface Group {
+  name: string
+}
+
+export const groupModel = model('Group', new Schema<Group>({
+  name: {
+    type: String,
+    required: true
+  }
+}))
+
+export const groupValidator = Joi.object({
+  _id: idValidator.required(),
+  name: Joi.string().trim().required()
+}).required()

--- a/backend/models/member.ts
+++ b/backend/models/member.ts
@@ -1,6 +1,7 @@
-import { model, Schema } from 'mongoose'
+import { model, Schema, Types } from 'mongoose'
 import Joi from 'joi'
 import { idValidator } from './common'
+import { groupModel } from './group'
 
 const HEX_COLOR_REGEXP = /^#[0-9a-fA-F]{6}$/
 
@@ -8,6 +9,7 @@ export interface Member {
   name: string
   color: string
   active: boolean
+  groups: Types.ObjectId[]
 }
 
 export const memberModel = model('Member', new Schema<Member>({
@@ -23,12 +25,19 @@ export const memberModel = model('Member', new Schema<Member>({
   active: {
     type: Boolean,
     required: true
-  }
+  },
+  groups: [
+    {
+      type: Schema.Types.ObjectId,
+      ref: groupModel
+    }
+  ]
 }))
 
 export const memberValidator = Joi.object({
   _id: idValidator.required(),
   name: Joi.string().trim().required(),
   color: Joi.string().pattern(HEX_COLOR_REGEXP).lowercase().required(),
-  active: Joi.boolean().required()
+  active: Joi.boolean().required(),
+  groups: Joi.array().items(idValidator)
 }).required()

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,14 +4,16 @@ import HomePage from './pages/HomePage'
 import CalendarPage from './pages/CalendarPage'
 import MembersPage from './pages/MembersPage'
 import ChoresPage from './pages/ChoresPage'
-import { membersActions } from './store/entities/members'
-import { useApiSliceBridge } from './api-slice-bridge'
-import { manualChoresActions } from './store/entities/manual-chores'
 import ConnectionModal from './components/ConnectionModal'
+import { useApiSliceBridge } from './api-slice-bridge'
+import { groupsActions } from './store/entities/groups'
+import { membersActions } from './store/entities/members'
+import { manualChoresActions } from './store/entities/manual-chores'
 import { scoreboardsActions } from './store/entities/scoreboards'
 import { periodicChoresActions } from './store/entities/periodic-chores'
 
 export default function App (): ReactElement {
+  useApiSliceBridge('groups', groupsActions)
   useApiSliceBridge('members', membersActions)
   useApiSliceBridge('manual-chores', manualChoresActions)
   useApiSliceBridge('scoreboards', scoreboardsActions)

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -1,4 +1,5 @@
 import { CrudRoute } from './crud-route'
+import { Group } from '../store/entities/groups'
 import { Member } from '../store/entities/members'
 import { ManualChore } from '../store/entities/manual-chores'
 import { Scoreboard } from '../store/entities/scoreboards'
@@ -8,6 +9,7 @@ import { PeriodicChore } from '../store/entities/periodic-chores'
  * A client for the REST API, mainly making accessible CRUD operations for all entity types.
  */
 export class Api {
+  readonly groups: CrudRoute<Group>
   readonly members: CrudRoute<Member>
   readonly manualChores: CrudRoute<ManualChore>
   readonly scoreboards: CrudRoute<Scoreboard>
@@ -16,6 +18,7 @@ export class Api {
   constructor (
     private readonly baseUrl: string
   ) {
+    this.groups = new CrudRoute(baseUrl + 'groups')
     this.members = new CrudRoute(baseUrl + 'members')
     this.manualChores = new CrudRoute(baseUrl + 'manual-chores')
     this.scoreboards = new CrudRoute(baseUrl + 'scoreboards')

--- a/frontend/src/editors/use-group-editor.ts
+++ b/frontend/src/editors/use-group-editor.ts
@@ -1,0 +1,17 @@
+import { Editor, useEditor } from './use-editor'
+import { Group } from '../store/entities/groups'
+
+const DEFAULT: Group = {
+  _id: '',
+  name: ''
+}
+
+export function useGroupEditor (value?: Group): Editor<Group> {
+  return useEditor({
+    value,
+    default: DEFAULT,
+    validate: entity => {
+      return entity.name.trim().length > 0
+    }
+  })
+}

--- a/frontend/src/editors/use-member-editor.ts
+++ b/frontend/src/editors/use-member-editor.ts
@@ -5,7 +5,8 @@ const DEFAULT: Member = {
   _id: '',
   name: '',
   color: '#000000',
-  active: true
+  active: true,
+  groups: []
 }
 
 export function useMemberEditor (value?: Member): Editor<Member> {

--- a/frontend/src/store/entities/groups.ts
+++ b/frontend/src/store/entities/groups.ts
@@ -1,0 +1,15 @@
+import { Selector } from '@reduxjs/toolkit'
+import { createEntitySlice } from '../create-entity-slice'
+import { RootState } from '../store'
+import { Entity } from '../entity'
+
+export interface Group extends Entity {
+  readonly name: string
+}
+
+const groupsSlice = createEntitySlice<Group>('groups')
+
+export const groupsActions = groupsSlice.actions
+export const selectGroups: Selector<RootState, Group[]> = state => state.groups
+
+export default groupsSlice.reducer

--- a/frontend/src/store/entities/members.ts
+++ b/frontend/src/store/entities/members.ts
@@ -7,6 +7,7 @@ export interface Member extends Entity {
   readonly name: string
   readonly color: string
   readonly active: boolean
+  readonly groups: readonly string[]
 }
 
 const membersSlice = createEntitySlice<Member>('members')

--- a/frontend/src/store/store.ts
+++ b/frontend/src/store/store.ts
@@ -4,9 +4,11 @@ import manualChores from './entities/manual-chores'
 import members from './entities/members'
 import periodicChores from './entities/periodic-chores'
 import scoreboards from './entities/scoreboards'
+import groups from './entities/groups'
 
 export const store = configureStore({
   reducer: {
+    groups,
     members,
     manualChores,
     scoreboards,


### PR DESCRIPTION
Sets up a new group model, which can be used to tag members. None, one
or multiple groups can be assigned to each user. Doing this will enable
better chore assignment in the future.