### PR TITLE
feat(components): Implement PeriodicChore group selection and filtering

### DIFF
--- a/frontend/src/components/chores/EditPeriodicChoreModal.tsx
+++ b/frontend/src/components/chores/EditPeriodicChoreModal.tsx
@@ -6,6 +6,38 @@ import FormRow from '../forms/FormRow'
 import { useParametrized } from '../../util/use-parametrized'
 import { PeriodicChore } from '../../store/entities/periodic-chores'
 import { usePeriodicChoreEditor } from '../../editors/use-periodic-chore-editor'
+import { Group, selectGroups } from '../../store/entities/groups'
+import { Editor } from '../../editors/use-editor'
+import { useAppSelector } from '../../store/store'
+import BasicDropdown from '../forms/BasicDropdown'
+
+function useGroupFormatter (): (item: Group | undefined) => string {
+  const { t } = useTranslation()
+  return item => item == null ? t('noneOption') : item.name
+}
+
+function ChoreGroupSelect (props: { editor: Editor<PeriodicChore> }): ReactElement {
+  const { editor } = props
+
+  const groups = useAppSelector(selectGroups)
+
+  const groupOptions = useMemo(() => [undefined, ...groups], [groups])
+  const groupFormatter = useGroupFormatter()
+  const groupValue = useMemo(() => {
+    return editor.value.groups.length !== 0
+      ? groups.find(item => item._id === editor.value.groups[0])
+      : undefined
+  }, [groups, editor.value.groups])
+
+  return (
+    <BasicDropdown
+      options={groupOptions}
+      formatter={groupFormatter}
+      value={groupValue}
+      onSelect={group => editor.update({ groups: group != null ? [group._id] : [] })}
+    />
+  )
+}
 
 interface Props {
   active: boolean
@@ -47,6 +79,9 @@ export default function EditPeriodicChoreModal (props: Props): ReactElement {
           value={editor.value.period}
           onChange={({ target }) => editor.update({ period: target.valueAsNumber })}
         />
+      </FormRow>
+      <FormRow label={t('periodic.fields.group')}>
+        <ChoreGroupSelect editor={editor} />
       </FormRow>
     </EditModal>
   )

--- a/frontend/src/components/chores/PeriodicChoreItem.tsx
+++ b/frontend/src/components/chores/PeriodicChoreItem.tsx
@@ -4,6 +4,7 @@ import EditPeriodicChoreModal from './EditPeriodicChoreModal'
 import EditableItem from '../items/EditableItem'
 import { PeriodicChore } from '../../store/entities/periodic-chores'
 import { EditModalRenderFn } from '../items/EditButton'
+import GroupTag from '../items/GroupTag'
 
 interface Props {
   chore: PeriodicChore
@@ -23,6 +24,7 @@ export default function PeriodicChoreItem (props: Props): ReactElement {
   return (
     <EditableItem renderModal={renderModal}>
       {props.chore.name}
+      {props.chore.groups.map((id, i) => <GroupTag key={i} id={id} />)}
     </EditableItem>
   )
 }

--- a/frontend/src/hooks/periodic-chores/use-planned-entry.ts
+++ b/frontend/src/hooks/periodic-chores/use-planned-entry.ts
@@ -11,12 +11,24 @@ export interface PlannedEntry {
   dueDays?: number
 }
 
-function usePreferredMember (chore: PeriodicChore): Member | undefined {
+function useActiveGroupMembers (groupIds: readonly string[]): Member[] {
   const members = useAppSelector(selectMembers)
 
   return useMemo(() => {
-    const activeMembers = members.filter(item => item.active)
+    return members.filter(member => {
+      if (!member.active) {
+        return false
+      }
+      // if groupIds is empty, any active member is okay, otherwise there needs to be a common subset of groups
+      return groupIds.length === 0 || member.groups.some(id => groupIds.includes(id))
+    })
+  }, [members, groupIds])
+}
 
+function usePreferredMember (chore: PeriodicChore): Member | undefined {
+  const activeMembers = useActiveGroupMembers(chore.groups)
+
+  return useMemo(() => {
     // no active members means nobody can complete the chore
     if (activeMembers.length === 0) {
       return undefined
@@ -33,7 +45,7 @@ function usePreferredMember (chore: PeriodicChore): Member | undefined {
 
     // choose the remaining member (if there are multiple, choose the one first in the alphabet)
     return remaining.sort((a, b) => a.name.localeCompare(b.name))[0]
-  }, [members, chore])
+  }, [activeMembers, chore])
 }
 
 /**

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -75,7 +75,8 @@
     "create": "Aufgabe erstellen",
     "fields": {
       "name": "Name",
-      "period": "Fällig nach ... Tagen"
+      "period": "Fällig nach ... Tagen",
+      "group": "Einschränkung auf Gruppe"
     }
   },
   "manual": {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -75,7 +75,8 @@
     "create": "Set up a chore",
     "fields": {
       "name": "Name",
-      "period": "Due after ... days"
+      "period": "Due after ... days",
+      "group": "Limit to group"
     }
   },
   "manual": {


### PR DESCRIPTION
A single group (or none) can now be selected in the
EditPeriodicChoreModal. If a group is set, the usePlannedEntry hook will
only propose active members with a matching group, otherwise it will
continue to use all active members.