### PR TITLE
feat: Implement editing of PeriodicChoreEntry inside of calendar

### DIFF
--- a/frontend/src/components/calendar/EditEntryModal.tsx
+++ b/frontend/src/components/calendar/EditEntryModal.tsx
@@ -55,7 +55,9 @@ export default function EditEntryModal (props: Props): ReactElement {
 
   const members = useAppSelector(selectMembers)
 
-  const memberOptions = useMemo(() => members.filter(item => item.active), [members])
+  const memberOptions = useMemo(() => {
+    return members.filter(item => item.active || item._id === props.entry.memberId)
+  }, [members, props.entry.memberId])
   const memberValue = useEntityById(selectMembers, editor.value.memberId)
 
   return (

--- a/frontend/src/components/calendar/EditEntryModal.tsx
+++ b/frontend/src/components/calendar/EditEntryModal.tsx
@@ -1,0 +1,80 @@
+import { ReactElement, useEffect, useMemo } from 'react'
+import EditModal from '../modals/EditModal'
+import { useTranslation } from 'react-i18next'
+import FormRow from '../forms/FormRow'
+import { useAppSelector } from '../../store/store'
+import { Member, selectMembers } from '../../store/entities/members'
+import BasicDropdown from '../forms/BasicDropdown'
+import { PeriodicChoreEntry } from '../../store/entities/periodic-chores'
+import { useEntityById } from '../../util/use-entity-by-id'
+import TextField from '../forms/TextField'
+import { Editor, useEditor } from '../../editors/use-editor'
+import { DateTime } from 'luxon'
+import { useParametrized } from '../../util/use-parametrized'
+
+const DEFAULT_ENTRY: PeriodicChoreEntry = {
+  date: DateTime.now().toUTC().toISO(),
+  memberId: ''
+}
+
+function useEntryEditor (value?: PeriodicChoreEntry): Editor<PeriodicChoreEntry> {
+  const members = useAppSelector(selectMembers)
+
+  return useEditor({
+    value,
+    default: DEFAULT_ENTRY,
+    validate: entry => {
+      return entry.date !== '' && entry.memberId !== '' && members.some(member => member._id === entry.memberId)
+    }
+  })
+}
+
+function formatMember (option: Member): string {
+  return option.name
+}
+
+function formatDate (date: string): string {
+  return DateTime.fromISO(date, { zone: 'utc' }).toLocal().toFormat('yyyy-MM-dd')
+}
+
+interface Props {
+  active: boolean
+  entry: PeriodicChoreEntry
+  onCancel: () => void
+  onSave: (entry: PeriodicChoreEntry) => void
+}
+
+export default function EditEntryModal (props: Props): ReactElement {
+  const { t } = useTranslation()
+
+  const editor = useEntryEditor(props.entry)
+  // reset editor when modal closes/opens
+  useEffect(() => editor.reset(), [editor, props.active])
+
+  const save = useParametrized(props.onSave, editor.value)
+
+  const members = useAppSelector(selectMembers)
+
+  const memberOptions = useMemo(() => members.filter(item => item.active), [members])
+  const memberValue = useEntityById(selectMembers, editor.value.memberId)
+
+  return (
+    <EditModal active={props.active}
+               title={t('calendar.edit')}
+               isValid={true}
+               onSave={save}
+               onCancel={props.onCancel}>
+      <FormRow label={t('calendar.fields.date')}>
+        <TextField disabled value={formatDate(props.entry.date)} />
+      </FormRow>
+      <FormRow label={t('calendar.fields.member')}>
+        <BasicDropdown
+          options={memberOptions}
+          formatter={formatMember}
+          value={memberValue}
+          onSelect={member => editor.update({ memberId: member._id })}
+        />
+      </FormRow>
+    </EditModal>
+  )
+}

--- a/frontend/src/components/calendar/PeriodicChoreCalendar.tsx
+++ b/frontend/src/components/calendar/PeriodicChoreCalendar.tsx
@@ -1,13 +1,16 @@
 import './PeriodicChoreCalendar.css'
-import { ReactElement, useCallback, useMemo } from 'react'
+import { ReactElement, useCallback, useMemo, useState } from 'react'
 import { PeriodicChore, PeriodicChoreEntry } from '../../store/entities/periodic-chores'
 import Calendar, { CellRenderFn } from './Calendar'
 import { DateTime } from 'luxon'
 import { useEntityById } from '../../util/use-entity-by-id'
 import { selectMembers } from '../../store/entities/members'
 import { PlannedEntry, usePlannedEntry } from '../../hooks/periodic-chores/use-planned-entry'
+import EditEntryModal from './EditEntryModal'
+import { useParametrized } from '../../util/use-parametrized'
+import api from '../../api/api'
 
-type EntryMap = Map<string, readonly PeriodicChoreEntry[]>
+type EntryMap = Map<string, readonly number[]>
 
 /**
  * Convert a date-time into an ISO date string (yyyy-MM-dd).
@@ -24,32 +27,62 @@ function formatDate (date: DateTime | string): string {
 
 /**
  * Transform the given array of entries into a map-lookup format,
- * where ISO date strings (yyyy-MM-dd) are keys, and their associated values are the respective
- * array of entries for that date.
+ * where ISO date strings (yyyy-MM-dd) are keys, and their associated values are arrays of indices into the
+ * provided array.
  *
  * @param items The items array.
- * @returns The resulting map for lookup of entries on a given date.
+ * @returns The resulting map for lookup of entry indices on a given date.
  */
 function useEntryMap (items: readonly PeriodicChoreEntry[]): EntryMap {
   return useMemo(() => {
-    const map = new Map<string, PeriodicChoreEntry[]>()
-    for (const item of items) {
-      const day = formatDate(item.date)
+    const map = new Map<string, number[]>()
+    for (let i = 0; i < items.length; ++i) {
+      const day = formatDate(items[i].date)
       const array = map.get(day) ?? []
-      array.push(item)
+      array.push(i)
       map.set(day, array)
     }
     return map
   }, [items])
 }
 
-function PeriodicChoreCalendarEntry (props: { entry: PeriodicChoreEntry }): ReactElement {
-  const member = useEntityById(selectMembers, props.entry.memberId)
+async function updateEntry (chore: PeriodicChore, index: number, entry: PeriodicChoreEntry): Promise<void> {
+  const newEntries = [...chore.entries]
+  newEntries[index] = entry
+  await api.periodicChores.update({
+    ...chore,
+    entries: newEntries
+  })
+}
+
+function PeriodicChoreCalendarEntry (props: { chore: PeriodicChore, entryIndex: number }): ReactElement {
+  const entry = props.chore.entries[props.entryIndex]
+
+  const member = useEntityById(selectMembers, entry.memberId)
+
+  const [editing, setEditing] = useState(false)
+  const startEditing = useParametrized(setEditing, true)
+  const cancelEditing = useParametrized(setEditing, false)
+
+  const save = useCallback(async (updatedEntry: PeriodicChoreEntry) => {
+    setEditing(false)
+    await updateEntry(props.chore, props.entryIndex, updatedEntry)
+  }, [props.chore, props.entryIndex])
 
   return (
-    <button className='PeriodicChoreCalendar-entry' style={{ backgroundColor: member?.color }}>
-      {member?.name ?? '???'}
-    </button>
+    <>
+      <button className='PeriodicChoreCalendar-entry'
+              style={{ backgroundColor: member?.color }}
+              onClick={startEditing}>
+        {member?.name ?? '???'}
+      </button>
+      <EditEntryModal
+        active={editing}
+        entry={entry}
+        onSave={save}
+        onCancel={cancelEditing}
+      />
+    </>
   )
 }
 
@@ -75,12 +108,14 @@ export default function PeriodicChoreCalendar (props: Props): ReactElement {
     if (planned?.dueDate != null && date.hasSame(planned.dueDate, 'day')) {
       return <PeriodicChoreCalendarPlannedEntry entry={planned} />
     }
-    const entries = map.get(formatDate(date))
-    if (entries == null) {
+    const entryIndices = map.get(formatDate(date))
+    if (entryIndices == null) {
       return undefined
     }
-    return entries.map((entry, i) => <PeriodicChoreCalendarEntry key={i} entry={entry} />)
-  }, [map, planned])
+    return entryIndices.map((index) => (
+      <PeriodicChoreCalendarEntry key={index} chore={props.chore} entryIndex={index} />
+    ))
+  }, [props.chore, map, planned])
 
   return (
     <Calendar renderCell={renderCell} />

--- a/frontend/src/editors/use-editor.ts
+++ b/frontend/src/editors/use-editor.ts
@@ -1,25 +1,24 @@
-import { Entity } from '../store/entity'
 import { Dispatch, DispatchWithoutAction, useEffect, useMemo, useState } from 'react'
 import { useSameObjectReference } from '../util/use-same-object-reference'
 
 /**
- * Options that can be passed to the editor hook to customize it for a specific entity type.
+ * Options that can be passed to the editor hook to customize it for a specific data type.
  */
-export interface EditorOptions<E extends Entity> {
-  value?: E
-  default: E
-  validate?: (value: E) => boolean
+export interface EditorOptions<T> {
+  value?: T
+  default: T
+  validate?: (value: T) => boolean
 }
 
 // similar to SetStateAction<S>, but allowing partial values
 export type UpdateStateAction<S> = Partial<S> | ((prevState: S) => Partial<S>)
 
 /**
- * An editor for an entity, containing the current value, update and reset methods, and a validity state.
+ * An editor for a data object, containing the current value, update and reset methods, and a validity state.
  */
-export interface Editor<E extends Entity> {
-  value: E
-  update: Dispatch<UpdateStateAction<E>>
+export interface Editor<T> {
+  value: T
+  update: Dispatch<UpdateStateAction<T>>
   reset: DispatchWithoutAction
   isValid: boolean
 }
@@ -37,11 +36,11 @@ function useValidation<T> (value: T, validator?: (value: T) => boolean): boolean
  * @param options The editor options.
  * @returns The editor.
  */
-export function useEditor<E extends Entity> (options: EditorOptions<E>): Editor<E> {
+export function useEditor<T> (options: EditorOptions<T>): Editor<T> {
   const initial = options.value ?? options.default
-  const [storedValue, setStoredValue] = useState<E>(initial)
+  const [storedValue, setStoredValue] = useState<T>(initial)
 
-  const update: Dispatch<UpdateStateAction<E>> = (value) => setStoredValue(previous => {
+  const update: Dispatch<UpdateStateAction<T>> = (value) => setStoredValue(previous => {
     const partial = value instanceof Function ? value(previous) : value
     return { ...previous, ...partial }
   })

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -41,6 +41,11 @@
       "friday": "Fr",
       "saturday": "Sa",
       "sunday": "So"
+    },
+    "edit": "Eintrag bearbeiten",
+    "fields": {
+      "date": "Datum",
+      "member": "Erledigt von"
     }
   },
   "groups": {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -41,6 +41,11 @@
       "friday": "Fri",
       "saturday": "Sat",
       "sunday": "Sun"
+    },
+    "edit": "Edit entry",
+    "fields": {
+      "date": "Date",
+      "member": "Completed by"
     }
   },
   "groups": {


### PR DESCRIPTION
By clicking on an entry in the calendar, an EditEntryModal is opened
which allows editing of that entry. So far, the date is displayed read-
only, while the member who completed the chore is fully changeable.
Clicking "Save" updates the PeriodicChore.