### PR TITLE
feat(components): Always show "Mark done" button in ManualChoreBox

### DIFF
--- a/frontend/src/components/forms/BasicButton.css
+++ b/frontend/src/components/forms/BasicButton.css
@@ -2,7 +2,7 @@
   display: inline-block;
   height: 36px;
   margin: 0 4px;
-  padding: 0 12px;
+  padding: 0 10px;
   font: inherit;
   font-size: 14px;
   font-weight: bold;

--- a/frontend/src/components/home/ChoreBox.css
+++ b/frontend/src/components/home/ChoreBox.css
@@ -1,7 +1,7 @@
 .ChoreBox {
   display: inline-block;
-  margin: 0 16px 16px 0;
-  padding: 12px;
+  margin: 0 12px 12px 0;
+  padding: 10px;
   vertical-align: top;
   background: #fff;
   border: 2px solid transparent;

--- a/frontend/src/components/home/ManualChoreBox.tsx
+++ b/frontend/src/components/home/ManualChoreBox.tsx
@@ -100,14 +100,14 @@ export default function ManualChoreBox (props: Props): ReactElement {
         {props.chore.name}
       </div>
       <div className='ManualChoreBox-actions'>
-        {isDue
-          ? (<BasicButton onClick={startMarkDone}>
-            {t('home.chores.markDone')}
-          </BasicButton>)
-          : (<BasicButton onClick={markDue}>
+        <BasicButton onClick={startMarkDone}>
+          {t('home.chores.markDone')}
+        </BasicButton>
+        {!isDue
+          ? (<BasicButton onClick={markDue}>
             {t('home.chores.markDue')}
           </BasicButton>)
-        }
+          : undefined}
       </div>
       <SelectMemberModal active={isSelectingMember} onSelect={confirmMarkDone} onCancel={cancelMarkDone} />
     </ChoreBox>

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -17,8 +17,8 @@
       "next": "Nächster Dienst",
       "nextFormat": "{{name}}",
       "nextFormatDays": "{{name}} (noch {{days}} Tag(e))",
-      "markDue": "Als fällig markieren",
-      "markDone": "Dienst eintragen"
+      "markDue": "Anfordern",
+      "markDone": "Eintragen"
     },
     "scoreboards": {
       "help": "Die Person weiter oben sollte den nächsten Dienst machen.",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -18,7 +18,7 @@
       "nextFormat": "{{name}}",
       "nextFormatDays": "{{name}} ({{days}} day(s) left)",
       "markDue": "Mark due",
-      "markDone": "Mark as done"
+      "markDone": "Mark done"
     },
     "scoreboards": {
       "help": "The person at the top should do the next chore.",


### PR DESCRIPTION
Someone who noticed that a chore should be due, but also immediately
completed that chore themselves, should be able to log this in a single
action. This is now possible. Additionally, some wording was updated to
make the buttons more compact, helping with displaying both at the same
time.