### PR TITLE
feat(components): Implement dense grid packing for cards on Home page

### DIFF
--- a/frontend/src/components/home/ChoreBox.css
+++ b/frontend/src/components/home/ChoreBox.css
@@ -1,8 +1,5 @@
 .ChoreBox {
-  display: inline-block;
-  margin: 0 12px 12px 0;
   padding: 10px;
-  vertical-align: top;
   background: #fff;
   border: 2px solid transparent;
   border-radius: 2px;
@@ -12,10 +9,4 @@
 .ChoreBox.urgent {
   background: #fffcf9;
   border-color: #ff3c00;
-}
-
-@media (max-width: 480px) {
-  .ChoreBox {
-    width: 100%;
-  }
 }

--- a/frontend/src/components/home/ChoreBox.tsx
+++ b/frontend/src/components/home/ChoreBox.tsx
@@ -1,6 +1,35 @@
 import './ChoreBox.css'
-import { PropsWithChildren, ReactElement } from 'react'
+import {
+  CSSProperties,
+  PropsWithChildren,
+  ReactElement,
+  RefObject, useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react'
 import clsx from 'clsx'
+
+function useOffsetHeight<E extends HTMLElement> (ref: RefObject<E>): number | undefined {
+  const [height, setHeight] = useState<number | undefined>()
+
+  const recompute = useCallback(() => {
+    if (ref.current != null) {
+      setHeight(ref.current.offsetHeight)
+    }
+  }, [ref])
+
+  useLayoutEffect(recompute, [recompute])
+
+  useEffect(() => {
+    const interval = setInterval(recompute, 2000)
+    return () => clearInterval(interval)
+  }, [recompute])
+
+  return height
+}
 
 interface Props {
   className?: string
@@ -8,8 +37,19 @@ interface Props {
 }
 
 export default function ChoreBox (props: PropsWithChildren<Props>): ReactElement {
+  const box = useRef<HTMLDivElement>(null)
+
+  const height = useOffsetHeight(box)
+
+  const style: CSSProperties = useMemo(() => {
+    const rows = height != null ? Math.ceil(height / 120) : 1
+    return { gridRowEnd: `span ${rows}` }
+  }, [height])
+
   return (
-    <div className={clsx('ChoreBox', props.className, { urgent: props.urgent })}>
+    <div ref={box}
+         className={clsx('ChoreBox', props.className, { urgent: props.urgent })}
+         style={style}>
       {props.children}
     </div>
   )

--- a/frontend/src/components/home/ChoreGrid.css
+++ b/frontend/src/components/home/ChoreGrid.css
@@ -1,0 +1,7 @@
+.ChoreGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  grid-auto-flow: dense;
+  align-items: start;
+  gap: 12px;
+}

--- a/frontend/src/components/home/ChoreGrid.tsx
+++ b/frontend/src/components/home/ChoreGrid.tsx
@@ -1,0 +1,10 @@
+import './ChoreGrid.css'
+import { PropsWithChildren, ReactElement } from 'react'
+
+export default function ChoreGrid (props: PropsWithChildren<{}>): ReactElement {
+  return (
+    <div className='ChoreGrid'>
+      {props.children}
+    </div>
+  )
+}

--- a/frontend/src/components/home/ManualChoreBox.css
+++ b/frontend/src/components/home/ManualChoreBox.css
@@ -1,7 +1,3 @@
-.ManualChoreBox {
-  min-width: 240px;
-}
-
 .ManualChoreBox-title {
   font-size: 24px;
 }

--- a/frontend/src/components/home/PeriodicChoreBox.css
+++ b/frontend/src/components/home/PeriodicChoreBox.css
@@ -1,7 +1,3 @@
-.PeriodicChoreBox {
-  min-width: 240px;
-}
-
 .PeriodicChoreBox-title {
   font-size: 24px;
   white-space: nowrap;

--- a/frontend/src/components/home/ScoreRow.css
+++ b/frontend/src/components/home/ScoreRow.css
@@ -1,6 +1,7 @@
 .ScoreRow {
   display: flex;
   margin: 4px 0;
+  line-height: 20px;
 }
 
 .ScoreRow-name {
@@ -8,7 +9,7 @@
 }
 
 .ScoreRow-bar {
-  width: 160px;
+  width: 100px;
   height: 20px;
   background: #c0e0d0;
 }

--- a/frontend/src/components/home/ScoreboardBox.css
+++ b/frontend/src/components/home/ScoreboardBox.css
@@ -1,7 +1,3 @@
-.ScoreboardBox {
-  width: 320px;
-}
-
 .ScoreboardBox-title {
   font-size: 24px;
   margin-bottom: 12px;
@@ -14,11 +10,4 @@
 .ScoreboardBox-info {
   margin-top: 12px;
   color: #888;
-}
-
-@media (max-width: 480px) {
-  .ScoreboardBox {
-    width: 100%;
-    min-width: 240px;
-  }
 }

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -9,6 +9,7 @@ import { selectPeriodicChores } from '../store/entities/periodic-chores'
 import PeriodicChoreBox from '../components/home/PeriodicChoreBox'
 import Empty from '../components/Empty'
 import { useTranslation } from 'react-i18next'
+import ChoreGrid from '../components/home/ChoreGrid'
 
 export default function HomePage (): ReactElement {
   const { t } = useTranslation()
@@ -22,9 +23,11 @@ export default function HomePage (): ReactElement {
   return (
     <NavigationBarLayout centered={empty}>
       {empty ? <Empty message={t('home.empty')} /> : undefined}
-      {periodicChores.map(chore => <PeriodicChoreBox key={chore._id} chore={chore} />)}
-      {scoreboards.map(scoreboard => <ScoreboardBox key={scoreboard._id} scoreboard={scoreboard} />)}
-      {manualChores.map(chore => <ManualChoreBox key={chore._id} chore={chore} />)}
+      <ChoreGrid>
+        {periodicChores.map(chore => <PeriodicChoreBox key={chore._id} chore={chore} />)}
+        {scoreboards.map(scoreboard => <ScoreboardBox key={scoreboard._id} scoreboard={scoreboard} />)}
+        {manualChores.map(chore => <ManualChoreBox key={chore._id} chore={chore} />)}
+      </ChoreGrid>
     </NavigationBarLayout>
   )
 }


### PR DESCRIPTION
By leveraging CSS grid layout with dense packing, and dynamically
assigning row span to each card based on its content height, the home
page can now potentially become more compact when there are items of
different sizes (such as a large scoreboard, and many small manual
chores).