### PR TITLE
feat(websocket): Add protocol-level ping every 20 seconds

### DIFF
--- a/backend/websocket/handler.ts
+++ b/backend/websocket/handler.ts
@@ -28,4 +28,7 @@ export function handler (controllers: Record<string, Controller<unknown>>, ws: W
   for (const [name, controller] of Object.entries(controllers)) {
     subscribe(ws, name, controller)
   }
+
+  const heartbeat = setInterval(() => ws.ping(), 20000)
+  ws.on('close', () => clearInterval(heartbeat))
 }


### PR DESCRIPTION
This should help the connection to stay open without regularly changing
entity data.