### PR TITLE
refactor(api): Unwrap responses and use client CrudRoute for list

### DIFF
--- a/backend/api/controller-route.ts
+++ b/backend/api/controller-route.ts
@@ -3,7 +3,7 @@ import { createHandler } from './create-handler'
 import { Controller } from '../controllers/controller'
 import { HTTP_CREATED } from './constants'
 
-export function createControllerRoute (controller: Controller<any>): Router {
+export function createControllerRoute<T = any> (controller: Controller<T>): Router {
   const router = Router()
 
   router.get('/', createHandler(async () => {
@@ -19,13 +19,12 @@ export function createControllerRoute (controller: Controller<any>): Router {
   }))
 
   router.put('/:id', createHandler(async (req) => {
-    await controller.update(req.params.id, req.body)
-    return {}
+    return { data: await controller.update(req.params.id, req.body) }
   }))
 
   router.delete('/:id', createHandler(async (req) => {
     await controller.delete(req.params.id)
-    return {}
+    return { data: {} }
   }))
 
   return router

--- a/backend/api/create-handler.ts
+++ b/backend/api/create-handler.ts
@@ -11,7 +11,6 @@ import { HTTP_BAD_REQUEST, HTTP_INTERNAL_SERVER_ERROR, HTTP_OK } from './constan
  */
 function sendError (res: Response, code: number, message: string): void {
   res.status(code).json({
-    success: false,
     error: message
   })
 }
@@ -23,10 +22,7 @@ function sendError (res: Response, code: number, message: string): void {
  * @param result The result to send.
  */
 function sendResult (res: Response, result: HandlerResponse): void {
-  res.status(result.code ?? HTTP_OK).json({
-    success: true,
-    data: result.data
-  })
+  res.status(result.code ?? HTTP_OK).json(result.data ?? {})
 }
 
 export interface HandlerResponse<T = any> {
@@ -38,7 +34,7 @@ export interface HandlerResponse<T = any> {
   /**
    * The response data to be sent as JSON. If absent, no data is sent.
    */
-  data?: T
+  data: T
 }
 
 function isSyntaxErrorWithStatus (error: unknown): error is SyntaxError & { status: number } {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,13 +12,14 @@ import { membersActions } from './store/entities/members'
 import { manualChoresActions } from './store/entities/manual-chores'
 import { scoreboardsActions } from './store/entities/scoreboards'
 import { periodicChoresActions } from './store/entities/periodic-chores'
+import api from './api/api'
 
 export default function App (): ReactElement {
-  useApiSliceBridge('groups', groupsActions)
-  useApiSliceBridge('members', membersActions)
-  useApiSliceBridge('manual-chores', manualChoresActions)
-  useApiSliceBridge('scoreboards', scoreboardsActions)
-  useApiSliceBridge('periodic-chores', periodicChoresActions)
+  useApiSliceBridge(groupsActions, 'groups', api.groups)
+  useApiSliceBridge(membersActions, 'members', api.members)
+  useApiSliceBridge(manualChoresActions, 'manual-chores', api.manualChores)
+  useApiSliceBridge(scoreboardsActions, 'scoreboards', api.scoreboards)
+  useApiSliceBridge(periodicChoresActions, 'periodic-chores', api.periodicChores)
 
   return (
     <BrowserRouter>

--- a/frontend/src/api-slice-bridge.ts
+++ b/frontend/src/api-slice-bridge.ts
@@ -3,29 +3,21 @@ import { useCallback, useEffect } from 'react'
 import { EntitySliceActions } from './store/create-entity-slice'
 import { useAppDispatch } from './store/store'
 import socket, { EVENT_MESSAGE, Message } from './websocket/socket'
+import { CrudRoute } from './api/crud-route'
 
-async function fetchEntityCollection<T extends Entity> (type: string): Promise<T[]> {
-  const response = await fetch(`/api/${type}`)
-  if (!response.ok) {
-    throw new Error('error fetching collection: ' + type)
-  }
-  const { data } = await response.json()
-  return data
-}
-
-function useEntityFetch<T extends Entity> (type: string, sliceActions: EntitySliceActions<T>): void {
+function useEntityFetch<T extends Entity> (sliceActions: EntitySliceActions<T>, crud: CrudRoute<T>): void {
   const dispatch = useAppDispatch()
 
   useEffect(() => {
     const fetchEntities = async (): Promise<void> => {
-      const initial = await fetchEntityCollection<T>(type)
+      const initial = await crud.list()
       dispatch(sliceActions.setEntities(initial))
     }
     fetchEntities().catch(console.error)
-  }, [dispatch, type, sliceActions])
+  }, [dispatch, sliceActions, crud])
 }
 
-function useEntitySocketEvents<T extends Entity> (type: string, sliceActions: EntitySliceActions<T>): void {
+function useEntitySocketEvents<T extends Entity> (sliceActions: EntitySliceActions<T>, type: string): void {
   const dispatch = useAppDispatch()
 
   const listener = useCallback((msg: Message): void => {
@@ -50,7 +42,7 @@ function useEntitySocketEvents<T extends Entity> (type: string, sliceActions: En
   }, [listener, sliceActions])
 }
 
-export function useApiSliceBridge<T extends Entity> (type: string, sliceActions: EntitySliceActions<T>): void {
-  useEntityFetch(type, sliceActions)
-  useEntitySocketEvents(type, sliceActions)
+export function useApiSliceBridge<T extends Entity> (sliceActions: EntitySliceActions<T>, type: string, crud: CrudRoute<T>): void {
+  useEntityFetch(sliceActions, crud)
+  useEntitySocketEvents(sliceActions, type)
 }

--- a/frontend/src/api/crud-route.ts
+++ b/frontend/src/api/crud-route.ts
@@ -10,6 +10,19 @@ export class CrudRoute<EntityType extends Entity> {
   }
 
   /**
+   * Obtain the entire list of entities.
+   *
+   * @returns A Promise that resolves with the collection when the request completes.
+   */
+  async list (): Promise<EntityType[]> {
+    const response = await fetch(this.collectionUrl)
+    if (!response.ok) {
+      throw new Error('collection could not be retrieved')
+    }
+    return await response.json()
+  }
+
+  /**
    * Create a new entity. The entity will match the given specification, but it will have a
    * unique id set by the server (if an id is present on the provided specification,
    * it will be ignored).


### PR DESCRIPTION
API calls no longer return objects with 'success' and 'data', but only
the data directly (success is immediately obvious from the HTTP status
code). The CrudRoute also gains a list method that is used for the API
slice bridge.