### PR TITLE
fix(components): Regularly update timestamp values in PeriodicChoreBox

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "i18next": "^21.0.2",
     "i18next-browser-languagedetector": "^6.1.2",
     "luxon": "^2.0.2",
+    "ms": "^2.1.3",
     "react": "^17.0.2",
     "react-circular-progressbar": "^2.0.4",
     "react-dom": "^17.0.2",
@@ -42,6 +43,7 @@
   "devDependencies": {
     "@types/body-scroll-lock": "^3.1.0",
     "@types/luxon": "^2.0.5",
+    "@types/ms": "^0.7.31",
     "@types/node": "^16.9.3",
     "@types/react": "^17.0.21",
     "@types/react-dom": "^17.0.9",

--- a/frontend/src/hooks/periodic-chores/use-days-since-last.ts
+++ b/frontend/src/hooks/periodic-chores/use-days-since-last.ts
@@ -1,7 +1,13 @@
 import { PeriodicChore } from '../../store/entities/periodic-chores'
 import { useMostRecent } from './use-most-recent'
-import { useMemo } from 'react'
 import { DateTime } from 'luxon'
+import ms from 'ms'
+import { useIntervalMemo } from '../../util/use-interval-memo'
+
+/**
+ * The time before the 'days since last' value is recomputed automatically.
+ */
+const UPDATE_PERIOD = ms('1 hour')
 
 /**
  * For a give chore, determine the number of days since last completion.
@@ -12,7 +18,7 @@ import { DateTime } from 'luxon'
 export function useDaysSinceLast (chore: PeriodicChore): number | undefined {
   const last = useMostRecent(chore.entries)
 
-  return useMemo(() => {
+  return useIntervalMemo(UPDATE_PERIOD, () => {
     if (last == null) {
       return undefined
     }

--- a/frontend/src/hooks/periodic-chores/use-planned-entry.ts
+++ b/frontend/src/hooks/periodic-chores/use-planned-entry.ts
@@ -4,6 +4,13 @@ import { Member, selectMembers } from '../../store/entities/members'
 import { useMemo } from 'react'
 import { DateTime } from 'luxon'
 import { useMostRecent } from './use-most-recent'
+import ms from 'ms'
+import { useIntervalMemo } from '../../util/use-interval-memo'
+
+/**
+ * The time before the 'dueDays' value is recomputed automatically.
+ */
+const UPDATE_PERIOD = ms('1 hour')
 
 export interface PlannedEntry {
   member: Member
@@ -59,7 +66,7 @@ export function usePlannedEntry (chore: PeriodicChore): PlannedEntry | undefined
   const last = useMostRecent(chore.entries)
   const member = usePreferredMember(chore)
 
-  return useMemo(() => {
+  return useIntervalMemo(UPDATE_PERIOD, () => {
     if (member == null) {
       return undefined
     }

--- a/frontend/src/util/use-interval-memo.ts
+++ b/frontend/src/util/use-interval-memo.ts
@@ -1,0 +1,37 @@
+import { DependencyList, useEffect, useMemo, useState } from 'react'
+
+/**
+ * A hook that periodically increments a counter, useful for invalidating dependencies in regular intervals.
+ *
+ * @param period The number of milliseconds between counter increments.
+ * @returns The counter value.
+ */
+function useCounter (period: number): number {
+  if (period <= 0) {
+    throw new Error(`expected a positive interval period, given ${period}`)
+  }
+
+  const [count, setCount] = useState(0)
+  useEffect(() => {
+    const interval = setInterval(() => setCount(c => c + 1), period)
+    return () => clearInterval(interval)
+  }, [period])
+
+  return count
+}
+
+/**
+ * A hook that works just like useMemo, but with an additional argument describing a time period,
+ * after which the value will be recomputed no matter if the dependencies changed or not.
+ * This can be used to implement relative timestamps, for example.
+ *
+ * @param period The auto-reset time period.
+ * @param factory The value factory.
+ * @param deps The regular dependencies of the factory function.
+ */
+export function useIntervalMemo<T> (period: number, factory: () => T, deps: DependencyList | undefined): T {
+  const updates = useCounter(period)
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  return useMemo(factory, deps == null ? [updates] : [...deps, updates])
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "i18next": "^21.0.2",
         "i18next-browser-languagedetector": "^6.1.2",
         "luxon": "^2.0.2",
+        "ms": "^2.1.3",
         "react": "^17.0.2",
         "react-circular-progressbar": "^2.0.4",
         "react-dom": "^17.0.2",
@@ -61,6 +62,7 @@
       "devDependencies": {
         "@types/body-scroll-lock": "^3.1.0",
         "@types/luxon": "^2.0.5",
+        "@types/ms": "^0.7.31",
         "@types/node": "^16.9.3",
         "@types/react": "^17.0.21",
         "@types/react-dom": "^17.0.9",
@@ -75,6 +77,11 @@
         "stylelint-config-standard": "^22.0.0",
         "typescript": "^4.4.3"
       }
+    },
+    "frontend/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/@babel/code-frame": {
       "version": "7.12.11",
@@ -3320,6 +3327,12 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
       "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
+      "dev": true
+    },
+    "node_modules/@types/ms": {
+      "version": "0.7.31",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -25964,6 +25977,12 @@
       "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
       "dev": true
     },
+    "@types/ms": {
+      "version": "0.7.31",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
+      "dev": true
+    },
     "@types/node": {
       "version": "16.11.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.0.tgz",
@@ -31213,6 +31232,7 @@
         "@reduxjs/toolkit": "^1.6.1",
         "@types/body-scroll-lock": "^3.1.0",
         "@types/luxon": "^2.0.5",
+        "@types/ms": "*",
         "@types/node": "^16.9.3",
         "@types/react": "^17.0.21",
         "@types/react-dom": "^17.0.9",
@@ -31227,6 +31247,7 @@
         "i18next": "^21.0.2",
         "i18next-browser-languagedetector": "^6.1.2",
         "luxon": "^2.0.2",
+        "ms": "^2.1.3",
         "react": "^17.0.2",
         "react-circular-progressbar": "^2.0.4",
         "react-dom": "^17.0.2",
@@ -31237,6 +31258,13 @@
         "stylelint": "^13.13.1",
         "stylelint-config-standard": "^22.0.0",
         "typescript": "^4.4.3"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        }
       }
     },
     "fs-extra": {


### PR DESCRIPTION
The urgency value, as well as the number of remaining days, is now
updated at least once an hour through a new custom hook that works
similarly to `useMemo` but resets itself automatically.