### PR TITLE
feat(components): Show page reload button in ConnectionModal

### DIFF
--- a/frontend/src/components/ConnectionModal.css
+++ b/frontend/src/components/ConnectionModal.css
@@ -1,0 +1,13 @@
+.ConnectionModal-reload {
+  display: block;
+  margin: 1rem auto 0;
+  padding: 4px;
+  font: inherit;
+  font-size: 0.875rem;
+  text-decoration: underline;
+  color: #666;
+  background: none;
+  border: none;
+  border-radius: 0;
+  cursor: pointer;
+}

--- a/frontend/src/components/ConnectionModal.tsx
+++ b/frontend/src/components/ConnectionModal.tsx
@@ -1,4 +1,5 @@
-import { ReactElement } from 'react'
+import './ConnectionModal.css'
+import { ReactElement, useEffect, useState } from 'react'
 import Modal from './modals/Modal'
 import { useConnectionStatusDebounced } from '../util/use-connection-status'
 import { useTranslation } from 'react-i18next'
@@ -9,14 +10,38 @@ import { useTranslation } from 'react-i18next'
  */
 const ALLOWED_DISCONNECT_TIME = 3000
 
+/**
+ * The time (in milliseconds) before the page reload button is shown to the user.
+ * The button is not shown instantly, to prevent data lass when the situation would have been recoverable.
+ */
+const DELAY_BEFORE_ENABLE_RELOAD = 5000
+
+function reloadPage (): void {
+  // eslint-disable-next-line no-restricted-globals
+  location.reload()
+}
+
 export default function ConnectionModal (): ReactElement {
   const { t } = useTranslation()
 
   const connected = useConnectionStatusDebounced(ALLOWED_DISCONNECT_TIME)
 
+  const [isReloadAllowed, setReloadAllowed] = useState(false)
+  useEffect(() => {
+    if (connected) {
+      setReloadAllowed(false)
+    } else {
+      const timeout = setTimeout(() => setReloadAllowed(true), DELAY_BEFORE_ENABLE_RELOAD)
+      return () => clearTimeout(timeout)
+    }
+  }, [connected])
+
   return (
     <Modal important active={!connected}>
       {t('lostConnection')}
+      {isReloadAllowed
+        ? <button className='ConnectionModal-reload' onClick={reloadPage}>{t('reloadPage')}</button>
+        : undefined}
     </Modal>
   )
 }

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -1,5 +1,6 @@
 {
   "lostConnection": "Verbindungsaufbau...",
+  "reloadPage": "Seite neuladen",
   "basicActions": {
     "add": "Hinzufügen",
     "edit": "Bearbeiten",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1,5 +1,6 @@
 {
   "lostConnection": "Trying to reconnect...",
+  "reloadPage": "reload page",
   "basicActions": {
     "add": "Add",
     "edit": "Edit",


### PR DESCRIPTION
If the connection has been lost for too long, the user is offered the
option to fully reload the page to potentially restore connectivity.