### PR TITLE
fix: Uniformly name backend build directory as 'build'

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint": "eslint --ignore-path .gitignore .",
     "lint-fix": "eslint --fix --ignore-path .gitignore .",
-    "build": "rimraf dist && tsc"
+    "build": "rimraf build && tsc"
   },
   "devDependencies": {
     "@types/express": "^4.17.13",

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -8,8 +8,8 @@
     "outDir": "./build"
   },
   "exclude": [
+    "node_modules",
     "test",
-    "dist",
-    "node_modules"
+    "build"
   ]
 }


### PR DESCRIPTION
In some places, the directory was still called 'dist'.