### PR TITLE
feat: Notify client of new version availability and show modal

### DIFF
--- a/backend/websocket/handler.ts
+++ b/backend/websocket/handler.ts
@@ -24,7 +24,15 @@ function subscribe (ws: WebSocket, controllerName: string, controller: Controlle
   })
 }
 
-export function handler (controllers: Record<string, Controller<unknown>>, ws: WebSocket): void {
+export function handler (controllers: Record<string, Controller<unknown>>, ws: WebSocket, pageVersion?: string): void {
+  // if available, send page version to client immediately on connect
+  if (pageVersion != null) {
+    ws.send(JSON.stringify({
+      event: 'pageVersion',
+      data: pageVersion
+    }))
+  }
+
   for (const [name, controller] of Object.entries(controllers)) {
     subscribe(ws, name, controller)
   }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import MembersPage from './pages/MembersPage'
 import ChoresPage from './pages/ChoresPage'
 import SettingsPage from './pages/SettingsPage'
 import ConnectionModal from './components/ConnectionModal'
+import UpdateModal from './components/UpdateModal'
 import { useApiSliceBridge } from './api-slice-bridge'
 import { groupsActions } from './store/entities/groups'
 import { membersActions } from './store/entities/members'
@@ -37,8 +38,8 @@ export default function App (): ReactElement {
         <Route path='*' element={<Navigate replace to='/' />} />
       </Routes>
 
-      {/* an overlay over the whole page displayed when connection is lost */}
       <ConnectionModal />
+      <UpdateModal />
     </BrowserRouter>
   )
 }

--- a/frontend/src/components/UpdateModal.css
+++ b/frontend/src/components/UpdateModal.css
@@ -1,0 +1,9 @@
+.UpdateModal-content {
+  max-width: 24rem;
+  text-align: center;
+  line-height: 1.5;
+}
+
+.UpdateModal-text {
+  margin: 0 0 1rem;
+}

--- a/frontend/src/components/UpdateModal.tsx
+++ b/frontend/src/components/UpdateModal.tsx
@@ -1,0 +1,31 @@
+import './UpdateModal.css'
+import { ReactElement } from 'react'
+import Modal from './modals/Modal'
+import { usePageOutdated } from '../util/use-page-outdated'
+import { useTranslation } from 'react-i18next'
+import BasicButton from './forms/BasicButton'
+import { faRedo } from '@fortawesome/free-solid-svg-icons'
+import Icon from './Icon'
+
+function reloadPage (): void {
+  // eslint-disable-next-line no-restricted-globals
+  location.reload()
+}
+
+export default function UpdateModal (): ReactElement {
+  const { t } = useTranslation()
+
+  const outdated = usePageOutdated()
+
+  return (
+    <Modal important active={outdated}>
+      <div className='UpdateModal-content'>
+        <div className='UpdateModal-text'>{t('outdated')}</div>
+        <BasicButton primary onClick={reloadPage}>
+          <Icon icon={faRedo} />
+          {t('reloadPage')}
+        </BasicButton>
+      </div>
+    </Modal>
+  )
+}

--- a/frontend/src/get-page-version.ts
+++ b/frontend/src/get-page-version.ts
@@ -1,0 +1,16 @@
+/**
+ * Determine the 'page version', that is, the chunk identifier of the currently running main chunk.
+ * This can then be compared to the value reported by the server to see if the page needs to be
+ * reloaded to keep functioning correctly.
+ *
+ * @returns The page version, or undefined if unable to determine.
+ */
+export function getPageVersion (): string | undefined {
+  if (document.currentScript != null && 'src' in document.currentScript) {
+    const match = document.currentScript.src.match(/main\.([0-9a-f]+?)\.chunk\.js/)
+    if (match != null && match.length >= 2) {
+      return match[1]
+    }
+    return undefined
+  }
+}

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -1,5 +1,6 @@
 {
   "lostConnection": "Verbindungsaufbau...",
+  "outdated": "Eine neue Version ist verfügbar. Bitte aktualisiere die Seite, um bestmögliche Kompatibilität sicherzustellen.",
   "reloadPage": "Seite neuladen",
   "basicActions": {
     "add": "Hinzufügen",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1,5 +1,6 @@
 {
   "lostConnection": "Trying to reconnect...",
+  "outdated": "There is a newer version available. Please reload the page to avoid incompatibilities.",
   "reloadPage": "reload page",
   "basicActions": {
     "add": "Add",

--- a/frontend/src/util/use-page-outdated.ts
+++ b/frontend/src/util/use-page-outdated.ts
@@ -1,0 +1,29 @@
+import { useEffect, useMemo, useState } from 'react'
+import { getPageVersion } from '../get-page-version'
+import socket, { EVENT_PAGE_VERSION } from '../websocket/socket'
+
+function useRemotePageVersion (): string | undefined {
+  const [version, setVersion] = useState(socket.reportedPageVersion)
+
+  useEffect(() => {
+    const listener = (version: string | undefined): void => setVersion(version)
+    socket.on(EVENT_PAGE_VERSION, listener)
+    return () => {
+      socket.off(EVENT_PAGE_VERSION, listener)
+    }
+  }, [])
+
+  return version
+}
+
+/**
+ * A custom hook to determine whether an updated script version is available on reload.
+ *
+ * @returns Update availability.
+ */
+export function usePageOutdated (): boolean {
+  const thisVersion = useMemo(() => getPageVersion(), [])
+  const remoteVersion = useRemotePageVersion()
+
+  return thisVersion != null && remoteVersion != null && thisVersion !== remoteVersion
+}


### PR DESCRIPTION
The hash of the running script is compared to the hash of the script
currently available on disk (reported by the server via WebSocket), and
if there is a mismatch, a modal is shown to the user prompting them to
reload the page. This is meant to avoid incompatibilities between
outdated clients interacting with up-to-date servers.