### PR TITLE
fix(components): Fix incorrect vertical align of horizontal nav toggle

### DIFF
--- a/frontend/src/components/NavigationBar.css
+++ b/frontend/src/components/NavigationBar.css
@@ -119,6 +119,7 @@
     display: inline-flex;
     width: var(--nav-thickness);
     height: 100%;
+    vertical-align: top;
   }
 
   .NavigationBar:not(.active) .NavigationBar-link {


### PR DESCRIPTION
The nav links would move slightly down relative to the toggle, leaving
a white gap at the top. This is now fixed.