### PR TITLE
refactor: Convert server.js to TypeScript

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,7 +5,8 @@
 !LICENSE
 !**/package.json
 !**/package-lock.json
-!server.js
+!server.ts
+!tsconfig.json
 !backend
 !frontend
 

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,2 +1,5 @@
 extends:
-- standard-with-typescript
+  - standard-with-typescript
+
+parserOptions:
+  project: './tsconfig.json'

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 node_modules
+build

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Fabian Meyer
+Copyright (c) 2021-2022 Fabian Meyer
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -75,14 +75,14 @@ is really just intended for development.
 
 Some hints on developing this project follow. This is irrelevant when all you want to do is run your own instance.
 
-The entire project is written in JavaScript and TypeScript. You should have a recent version of Node (16 or later)
-and NPM installed. Since we are using NPM Workspaces, NPM 7 or later is required.
+The entire project is written in TypeScript. You should have a recent version of Node (16 or later) and NPM installed.
+Since we are using NPM Workspaces, NPM 7 or later is required.
 
 - The `backend` workspace contains the database connection and everything else required to make the system work,
   such as an API.
 - The `frontend` workspace contains a React app that is the user interface.
-- Finally, there is the `server.js` file used to bootstrap the backend and also serve compiled frontend files.
-  This is written in plain JavaScript for simplicity reasons.
+- Finally, there is the `server.ts` file used to bootstrap the backend and also serve compiled frontend files. This
+  is the entrypoint for the root package.
 
 ### Start scripts
 
@@ -103,7 +103,7 @@ There are many great editor integrations for ESLint, Stylelint and TypeScript; u
 
 ### Dependency management
 
-To install a new dependency, you have to decide: is it needed everywhere, like ESLint? Is it required by `server.js`?
+To install a new dependency, you have to decide: is it needed everywhere, like ESLint? Is it required by `server.ts`?
 If the answer was 'yes' to at least one of these questions, install the dependency to the root folder
 (e.g. `npm i express`).
 Otherwise, install it to the appropriate workspace: `npm i -w frontend react`.

--- a/backend/.eslintrc.yml
+++ b/backend/.eslintrc.yml
@@ -1,5 +1,5 @@
 extends:
-- standard-with-typescript
+  - standard-with-typescript
 
 parserOptions:
   project: './tsconfig.json'

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -10,6 +10,8 @@ import { createRouter, createErrorHandler } from './api/api'
 import { handler as wsHandler } from './websocket/handler'
 import { MemberController } from './controllers/member-controller'
 
+export { Environment } from './environment'
+
 const groupsController = new Controller(groupModel, groupValidator)
 const membersController = new MemberController({
   group: groupsController

--- a/backend/package.json
+++ b/backend/package.json
@@ -3,17 +3,11 @@
   "version": "0.0.0",
   "private": true,
   "main": "build/index.js",
+  "types": "build/index.d.ts",
   "scripts": {
     "lint": "eslint --ignore-path .gitignore . && tsc --noEmit",
     "lint-fix": "eslint --fix --ignore-path .gitignore . && tsc --noEmit",
     "build": "rimraf build && tsc"
-  },
-  "devDependencies": {
-    "@types/express": "4.17.13",
-    "@types/node": "16.11.25",
-    "@types/ws": "8.2.2",
-    "rimraf": "3.0.2",
-    "typescript": "4.5.5"
   },
   "dependencies": {
     "joi": "17.6.0",

--- a/frontend/.eslintrc.yml
+++ b/frontend/.eslintrc.yml
@@ -1,22 +1,22 @@
 extends:
-- standard-with-typescript
-- react-app
-- plugin:react/recommended
-- plugin:react/jsx-runtime
+  - standard-with-typescript
+  - react-app
+  - plugin:react/recommended
+  - plugin:react/jsx-runtime
 
 parserOptions:
   project: './tsconfig.json'
 
 ignorePatterns:
-- 'src/react-app-env.d.ts'
+  - 'src/react-app-env.d.ts'
 
 rules:
-  jsx-quotes: [ error, prefer-single ]
-  'react/jsx-indent': [ error, 2 ]
-  'react/jsx-wrap-multilines': [ warn, {
+  jsx-quotes: [error, prefer-single]
+  'react/jsx-indent': [error, 2]
+  'react/jsx-wrap-multilines': [warn, {
     return: parens-new-line,
     arrow: parens-new-line
-  } ]
+  }]
   'react/void-dom-elements-no-children': [error]
   'react/no-unstable-nested-components': [error]
   'react/prop-types': [error, {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,17 +44,14 @@
     "@types/body-scroll-lock": "3.1.0",
     "@types/luxon": "2.0.9",
     "@types/ms": "0.7.31",
-    "@types/node": "16.11.25",
     "@types/react": "17.0.39",
     "@types/react-dom": "17.0.11",
     "@types/react-redux": "7.1.22",
-    "eslint-plugin-node": "11.1.0",
     "eslint-plugin-react": "7.28.0",
     "eslint-plugin-react-hooks": "4.3.0",
     "http-proxy-middleware": "2.0.3",
     "react-scripts": "4.0.3",
     "stylelint": "14.5.0",
-    "stylelint-config-standard": "25.0.0",
-    "typescript": "4.5.5"
+    "stylelint-config-standard": "25.0.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,11 +17,16 @@
         "ws": "8.5.0"
       },
       "devDependencies": {
+        "@types/express": "4.17.13",
+        "@types/node": "16.11.25",
+        "@types/ws": "8.2.2",
         "eslint": "7.32.0",
         "eslint-config-standard-with-typescript": "21.0.1",
         "eslint-plugin-import": "2.25.4",
         "eslint-plugin-node": "11.1.0",
-        "eslint-plugin-promise": "5.2.0"
+        "eslint-plugin-promise": "5.2.0",
+        "rimraf": "3.0.2",
+        "typescript": "4.5.5"
       }
     },
     "backend": {
@@ -30,13 +35,6 @@
         "joi": "17.6.0",
         "mongoose": "6.2.1",
         "tiny-typed-emitter": "2.1.0"
-      },
-      "devDependencies": {
-        "@types/express": "4.17.13",
-        "@types/node": "16.11.25",
-        "@types/ws": "8.2.2",
-        "rimraf": "3.0.2",
-        "typescript": "4.5.5"
       }
     },
     "frontend": {
@@ -63,18 +61,15 @@
         "@types/body-scroll-lock": "3.1.0",
         "@types/luxon": "2.0.9",
         "@types/ms": "0.7.31",
-        "@types/node": "16.11.25",
         "@types/react": "17.0.39",
         "@types/react-dom": "17.0.11",
         "@types/react-redux": "7.1.22",
-        "eslint-plugin-node": "11.1.0",
         "eslint-plugin-react": "7.28.0",
         "eslint-plugin-react-hooks": "4.3.0",
         "http-proxy-middleware": "2.0.3",
         "react-scripts": "4.0.3",
         "stylelint": "14.5.0",
-        "stylelint-config-standard": "25.0.0",
-        "typescript": "4.5.5"
+        "stylelint-config-standard": "25.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -26950,14 +26945,9 @@
     "backend": {
       "version": "file:backend",
       "requires": {
-        "@types/express": "4.17.13",
-        "@types/node": "16.11.25",
-        "@types/ws": "8.2.2",
         "joi": "17.6.0",
         "mongoose": "6.2.1",
-        "rimraf": "3.0.2",
-        "tiny-typed-emitter": "2.1.0",
-        "typescript": "4.5.5"
+        "tiny-typed-emitter": "2.1.0"
       }
     },
     "balanced-match": {
@@ -30749,13 +30739,11 @@
         "@types/body-scroll-lock": "3.1.0",
         "@types/luxon": "2.0.9",
         "@types/ms": "0.7.31",
-        "@types/node": "16.11.25",
         "@types/react": "17.0.39",
         "@types/react-dom": "17.0.11",
         "@types/react-redux": "7.1.22",
         "body-scroll-lock": "4.0.0-beta.0",
         "clsx": "1.1.1",
-        "eslint-plugin-node": "11.1.0",
         "eslint-plugin-react": "7.28.0",
         "eslint-plugin-react-hooks": "4.3.0",
         "http-proxy-middleware": "2.0.3",
@@ -30771,8 +30759,7 @@
         "react-router-dom": "6.2.1",
         "react-scripts": "4.0.3",
         "stylelint": "14.5.0",
-        "stylelint-config-standard": "25.0.0",
-        "typescript": "4.5.5"
+        "stylelint-config-standard": "25.0.0"
       }
     },
     "fs-extra": {

--- a/package.json
+++ b/package.json
@@ -3,15 +3,16 @@
   "version": "0.1.0",
   "private": true,
   "description": "Management system for flat sharing",
-  "main": "server.js",
+  "main": "build/server.js",
   "workspaces": [
     "backend",
     "frontend"
   ],
   "scripts": {
-    "build-all": "npm run build --workspaces --if-present",
+    "build-all": "npm run build --workspaces --if-present && npm run build",
+    "build": "rimraf build && tsc",
     "start": "npm run build-all && npm run production",
-    "production": "node server.js",
+    "production": "node build/server.js",
     "dev": "npm start -w frontend",
     "lint-all": "npm run lint --workspaces --if-present",
     "lint-fix-all": "npm run lint-fix --workspaces --if-present"
@@ -27,11 +28,16 @@
   },
   "homepage": "https://github.com/meyfa/wg-system#readme",
   "devDependencies": {
+    "@types/express": "4.17.13",
+    "@types/node": "16.11.25",
+    "@types/ws": "8.2.2",
     "eslint": "7.32.0",
     "eslint-config-standard-with-typescript": "21.0.1",
     "eslint-plugin-import": "2.25.4",
     "eslint-plugin-node": "11.1.0",
-    "eslint-plugin-promise": "5.2.0"
+    "eslint-plugin-promise": "5.2.0",
+    "rimraf": "3.0.2",
+    "typescript": "4.5.5"
   },
   "dependencies": {
     "express": "4.17.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es2018",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "strict": true,
+    "outDir": "./build"
+  },
+  "include": [
+    "server.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "test",
+    "build",
+    "backend",
+    "frontend"
+  ]
+}


### PR DESCRIPTION
We now have proper type safety in the main server file, too. A build
step is added to the build-all script for building the server.js file.
The Dockerfile is also adapted to include an additional stage.