### PR TITLE
refactor: Convert backend and server to EcmaScript modules

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -3,3 +3,6 @@ extends:
 
 parserOptions:
   project: './tsconfig.json'
+
+rules:
+  'import/extensions': [error, always]

--- a/backend/.eslintrc.yml
+++ b/backend/.eslintrc.yml
@@ -3,3 +3,6 @@ extends:
 
 parserOptions:
   project: './tsconfig.json'
+
+rules:
+  'import/extensions': [error, always]

--- a/backend/api/api.ts
+++ b/backend/api/api.ts
@@ -1,8 +1,8 @@
 import { ErrorRequestHandler, Router } from 'express'
-import { createHandler, handleError } from './create-handler'
-import { NotFoundError } from './errors'
-import { Controller } from '../controllers/controller'
-import { createControllerRoute } from './controller-route'
+import { createHandler, handleError } from './create-handler.js'
+import { NotFoundError } from './errors.js'
+import { Controller } from '../controllers/controller.js'
+import { createControllerRoute } from './controller-route.js'
 
 export function createRouter (controllers: Record<string, Controller<unknown>>): Router {
   const router = Router()

--- a/backend/api/controller-route.ts
+++ b/backend/api/controller-route.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express'
-import { createHandler } from './create-handler'
-import { Controller } from '../controllers/controller'
-import { HTTP_CREATED } from './constants'
+import { createHandler } from './create-handler.js'
+import { Controller } from '../controllers/controller.js'
+import { HTTP_CREATED } from './constants.js'
 
 export function createControllerRoute<T = any> (controller: Controller<T>): Router {
   const router = Router()

--- a/backend/api/create-handler.ts
+++ b/backend/api/create-handler.ts
@@ -1,6 +1,6 @@
 import { Request, RequestHandler, Response } from 'express'
-import { ApiError } from './errors'
-import { HTTP_BAD_REQUEST, HTTP_INTERNAL_SERVER_ERROR, HTTP_OK } from './constants'
+import { ApiError } from './errors.js'
+import { HTTP_BAD_REQUEST, HTTP_INTERNAL_SERVER_ERROR, HTTP_OK } from './constants.js'
 
 /**
  * Respond with an error message.

--- a/backend/api/errors.ts
+++ b/backend/api/errors.ts
@@ -1,4 +1,4 @@
-import { HTTP_BAD_REQUEST, HTTP_NOT_FOUND } from './constants'
+import { HTTP_BAD_REQUEST, HTTP_NOT_FOUND } from './constants.js'
 
 /**
  * A special type of error that is intentionally thrown by the API.

--- a/backend/controllers/controller.ts
+++ b/backend/controllers/controller.ts
@@ -1,6 +1,6 @@
-import { HydratedDocument, Model, Types } from 'mongoose'
+import mongoose, { HydratedDocument, Model } from 'mongoose'
 import Joi, { ObjectSchema } from 'joi'
-import { BadRequestError, NotFoundError } from '../api/errors'
+import { BadRequestError, NotFoundError } from '../api/errors.js'
 import { TypedEmitter } from 'tiny-typed-emitter'
 
 export type Doc<EntityType> = HydratedDocument<EntityType>
@@ -37,7 +37,7 @@ export class Controller<EntityType> extends TypedEmitter<ControllerEvents<Entity
   }
 
   async find (id: string): Promise<Doc<EntityType>> {
-    if (!Types.ObjectId.isValid(id)) {
+    if (!mongoose.Types.ObjectId.isValid(id)) {
       throw new NotFoundError()
     }
     const item = await this.model.findById(id)
@@ -55,7 +55,7 @@ export class Controller<EntityType> extends TypedEmitter<ControllerEvents<Entity
   }
 
   async update (id: string, data: any): Promise<Doc<EntityType>> {
-    if (!Types.ObjectId.isValid(id)) {
+    if (!mongoose.Types.ObjectId.isValid(id)) {
       throw new NotFoundError()
     }
     const item = await this.find(id)
@@ -66,7 +66,7 @@ export class Controller<EntityType> extends TypedEmitter<ControllerEvents<Entity
   }
 
   async delete (id: string): Promise<Doc<EntityType>> {
-    if (!Types.ObjectId.isValid(id)) {
+    if (!mongoose.Types.ObjectId.isValid(id)) {
       throw new NotFoundError()
     }
     const item = await this.model.findByIdAndDelete(id)

--- a/backend/controllers/manual-chore-controller.ts
+++ b/backend/controllers/manual-chore-controller.ts
@@ -1,7 +1,7 @@
-import { Controller, Doc } from './controller'
+import { Controller, Doc } from './controller.js'
 import { QueryCursor } from 'mongoose'
-import { ManualChore, manualChoreModel, manualChoreValidator } from '../models/manual-chore'
-import { Scoreboard } from '../models/scoreboard'
+import { ManualChore, manualChoreModel, manualChoreValidator } from '../models/manual-chore.js'
+import { Scoreboard } from '../models/scoreboard.js'
 
 export interface ManualChoreDependencies {
   scoreboard: Controller<Scoreboard>

--- a/backend/controllers/member-controller.ts
+++ b/backend/controllers/member-controller.ts
@@ -1,9 +1,9 @@
-import { Controller, Doc } from './controller'
-import { Member, memberModel, memberValidator } from '../models/member'
-import { QueryCursor, Types } from 'mongoose'
-import { Group } from '../models/group'
+import { Controller, Doc } from './controller.js'
+import { Member, memberModel, memberValidator } from '../models/member.js'
+import mongoose, { QueryCursor } from 'mongoose'
+import { Group } from '../models/group.js'
 
-function removeObjectId (ids: readonly Types.ObjectId[], remove: Types.ObjectId): Types.ObjectId[] {
+function removeObjectId<T extends mongoose.Types.ObjectId> (ids: readonly T[], remove: T): T[] {
   // this is to avoid a linter error, because for some reason typescript-eslint thinks that
   // id.equals does not result in a boolean if its parameter is of type 'any', which,
   // again for some reason unknown to me, other._id seems to be (Mongoose, what did you do?)

--- a/backend/controllers/periodic-chore-controller.ts
+++ b/backend/controllers/periodic-chore-controller.ts
@@ -1,6 +1,6 @@
-import { Controller, Doc } from './controller'
-import { PeriodicChore, periodicChoreModel, periodicChoreValidator } from '../models/periodic-chore'
-import { Member } from '../models/member'
+import { Controller, Doc } from './controller.js'
+import { PeriodicChore, periodicChoreModel, periodicChoreValidator } from '../models/periodic-chore.js'
+import { Member } from '../models/member.js'
 import { QueryCursor } from 'mongoose'
 
 export interface PeriodicChoreDependencies {

--- a/backend/controllers/scoreboard-controller.ts
+++ b/backend/controllers/scoreboard-controller.ts
@@ -1,7 +1,7 @@
-import { Controller, Doc } from './controller'
-import { Member } from '../models/member'
+import { Controller, Doc } from './controller.js'
+import { Member } from '../models/member.js'
 import { QueryCursor } from 'mongoose'
-import { Scoreboard, scoreboardModel, scoreboardValidator } from '../models/scoreboard'
+import { Scoreboard, scoreboardModel, scoreboardValidator } from '../models/scoreboard.js'
 
 export interface ScoreboardDependencies {
   member: Controller<Member>

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -1,16 +1,16 @@
 import mongoose from 'mongoose'
-import { Environment } from './environment'
-import { Controller } from './controllers/controller'
-import { groupModel, groupValidator } from './models/group'
-import { ScoreboardController } from './controllers/scoreboard-controller'
-import { ManualChoreController } from './controllers/manual-chore-controller'
-import { PeriodicChoreController } from './controllers/periodic-chore-controller'
+import { Environment } from './environment.js'
+import { Controller } from './controllers/controller.js'
+import { groupModel, groupValidator } from './models/group.js'
+import { ScoreboardController } from './controllers/scoreboard-controller.js'
+import { ManualChoreController } from './controllers/manual-chore-controller.js'
+import { PeriodicChoreController } from './controllers/periodic-chore-controller.js'
 
-import { createRouter, createErrorHandler } from './api/api'
-import { handler as wsHandler } from './websocket/handler'
-import { MemberController } from './controllers/member-controller'
+import { createRouter, createErrorHandler } from './api/api.js'
+import { handler as wsHandler } from './websocket/handler.js'
+import { MemberController } from './controllers/member-controller.js'
 
-export { Environment } from './environment'
+export { Environment } from './environment.js'
 
 const groupsController = new Controller(groupModel, groupValidator)
 const membersController = new MemberController({

--- a/backend/models/group.ts
+++ b/backend/models/group.ts
@@ -1,12 +1,12 @@
-import { model, Schema } from 'mongoose'
+import mongoose from 'mongoose'
 import Joi from 'joi'
-import { idValidator } from './common'
+import { idValidator } from './common.js'
 
 export interface Group {
   name: string
 }
 
-export const groupModel = model('Group', new Schema<Group>({
+export const groupModel = mongoose.model('Group', new mongoose.Schema<Group>({
   name: {
     type: String,
     required: true

--- a/backend/models/manual-chore.ts
+++ b/backend/models/manual-chore.ts
@@ -1,15 +1,15 @@
-import { model, Schema, Types } from 'mongoose'
+import mongoose from 'mongoose'
 import Joi from 'joi'
-import { scoreboardModel } from './scoreboard'
-import { idValidator } from './common'
+import { scoreboardModel } from './scoreboard.js'
+import { idValidator } from './common.js'
 
 export interface ManualChore {
   name: string
   dueSince: number
-  scoreboardId: Types.ObjectId | null
+  scoreboardId: mongoose.Types.ObjectId | null
 }
 
-export const manualChoreModel = model('ManualChore', new Schema<ManualChore>({
+export const manualChoreModel = mongoose.model('ManualChore', new mongoose.Schema<ManualChore>({
   name: {
     type: String,
     required: true
@@ -20,7 +20,7 @@ export const manualChoreModel = model('ManualChore', new Schema<ManualChore>({
     min: 0
   },
   scoreboardId: {
-    type: Schema.Types.ObjectId,
+    type: mongoose.Schema.Types.ObjectId,
     required: false,
     ref: scoreboardModel
   }

--- a/backend/models/member.ts
+++ b/backend/models/member.ts
@@ -1,7 +1,7 @@
-import { model, Schema, Types } from 'mongoose'
+import mongoose from 'mongoose'
 import Joi from 'joi'
-import { idValidator } from './common'
-import { groupModel } from './group'
+import { idValidator } from './common.js'
+import { groupModel } from './group.js'
 
 const HEX_COLOR_REGEXP = /^#[0-9a-fA-F]{6}$/
 
@@ -9,10 +9,10 @@ export interface Member {
   name: string
   color: string
   active: boolean
-  groups: Types.ObjectId[]
+  groups: mongoose.Types.ObjectId[]
 }
 
-export const memberModel = model('Member', new Schema<Member>({
+export const memberModel = mongoose.model('Member', new mongoose.Schema<Member>({
   name: {
     type: String,
     required: true
@@ -28,7 +28,7 @@ export const memberModel = model('Member', new Schema<Member>({
   },
   groups: [
     {
-      type: Schema.Types.ObjectId,
+      type: mongoose.Schema.Types.ObjectId,
       ref: groupModel
     }
   ]

--- a/backend/models/periodic-chore.ts
+++ b/backend/models/periodic-chore.ts
@@ -1,22 +1,22 @@
-import { model, Schema, Types } from 'mongoose'
+import mongoose from 'mongoose'
 import Joi from 'joi'
-import { idValidator } from './common'
-import { memberModel } from './member'
-import { groupModel } from './group'
+import { idValidator } from './common.js'
+import { memberModel } from './member.js'
+import { groupModel } from './group.js'
 
 export interface PeriodicChoreEntry {
-  memberId: Types.ObjectId
+  memberId: mongoose.Types.ObjectId
   date: string
 }
 
 export interface PeriodicChore {
   name: string
   period: number
-  groups: Types.ObjectId[]
+  groups: mongoose.Types.ObjectId[]
   entries: PeriodicChoreEntry[]
 }
 
-export const periodicChoreModel = model('PeriodicChore', new Schema<PeriodicChore>({
+export const periodicChoreModel = mongoose.model('PeriodicChore', new mongoose.Schema<PeriodicChore>({
   name: {
     type: String,
     required: true
@@ -28,7 +28,7 @@ export const periodicChoreModel = model('PeriodicChore', new Schema<PeriodicChor
   },
   groups: [
     {
-      type: Schema.Types.ObjectId,
+      type: mongoose.Schema.Types.ObjectId,
       ref: groupModel
     }
   ],
@@ -36,7 +36,7 @@ export const periodicChoreModel = model('PeriodicChore', new Schema<PeriodicChor
     {
       _id: false,
       memberId: {
-        type: Schema.Types.ObjectId,
+        type: mongoose.Schema.Types.ObjectId,
         required: true,
         ref: memberModel
       },

--- a/backend/models/scoreboard.ts
+++ b/backend/models/scoreboard.ts
@@ -1,10 +1,10 @@
-import { model, Schema, Types } from 'mongoose'
-import { memberModel } from './member'
+import mongoose from 'mongoose'
+import { memberModel } from './member.js'
 import Joi from 'joi'
-import { idValidator } from './common'
+import { idValidator } from './common.js'
 
 export interface ScoreboardEntry {
-  memberId: Types.ObjectId
+  memberId: mongoose.Types.ObjectId
   offset: number
   score: number
 }
@@ -14,7 +14,7 @@ export interface Scoreboard {
   scores: ScoreboardEntry[]
 }
 
-export const scoreboardModel = model('Scoreboard', new Schema<Scoreboard>({
+export const scoreboardModel = mongoose.model('Scoreboard', new mongoose.Schema<Scoreboard>({
   name: {
     type: String,
     required: true
@@ -23,7 +23,7 @@ export const scoreboardModel = model('Scoreboard', new Schema<Scoreboard>({
     {
       _id: false,
       memberId: {
-        type: Schema.Types.ObjectId,
+        type: mongoose.Schema.Types.ObjectId,
         required: true,
         ref: memberModel
       },

--- a/backend/package.json
+++ b/backend/package.json
@@ -2,6 +2,7 @@
   "name": "backend",
   "version": "0.0.0",
   "private": true,
+  "type": "module",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "scripts": {

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
     "target": "es2018",
-    "module": "commonjs",
+    "module": "es2020",
     "esModuleInterop": true,
-    "resolveJsonModule": true,
+    "moduleResolution": "Node",
     "strict": true,
     "declaration": true,
     "outDir": "./build"

--- a/backend/websocket/handler.ts
+++ b/backend/websocket/handler.ts
@@ -1,5 +1,5 @@
 import WebSocket from 'ws'
-import { Controller, ControllerListener } from '../controllers/controller'
+import { Controller, ControllerListener } from '../controllers/controller.js'
 
 function subscribe (ws: WebSocket, controllerName: string, controller: Controller<unknown>): void {
   const sendEvent = (type: string, item: any): void => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,9 @@
         "eslint-plugin-promise": "5.2.0",
         "rimraf": "3.0.2",
         "typescript": "4.5.5"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "backend": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "description": "Management system for flat sharing",
+  "type": "module",
   "main": "build/server.js",
   "workspaces": [
     "backend",
@@ -16,6 +17,9 @@
     "dev": "npm start -w frontend",
     "lint-all": "npm run lint --workspaces --if-present",
     "lint-fix-all": "npm run lint-fix --workspaces --if-present"
+  },
+  "engines": {
+    "node": ">=16.0.0"
   },
   "repository": {
     "type": "git",

--- a/server.ts
+++ b/server.ts
@@ -1,10 +1,14 @@
 import express from 'express'
+import { fileURLToPath } from 'url'
 import path from 'path'
 import fs from 'fs'
 import { WebSocketServer } from 'ws'
 
 // this works because 'backend' is listed as a workspace in package.json
 import { init, createApiRouter, createApiErrorHandler, webSocketHandler, Environment } from 'backend'
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 // after compilation, this file ends up in './build', so the root is one level up
 const PROJECT_ROOT = path.join(__dirname, '..')

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
     "target": "es2018",
-    "module": "commonjs",
+    "module": "es2020",
     "esModuleInterop": true,
-    "resolveJsonModule": true,
+    "moduleResolution": "Node",
     "strict": true,
     "outDir": "./build"
   },


### PR DESCRIPTION
This will allow us to depend on ESM-only NPM packages, which are
becoming increasingly commonplace.