### PR TITLE
refactor(backend): Inject mongoose.Connection instead of using default

### DIFF
--- a/backend/controllers/controller.ts
+++ b/backend/controllers/controller.ts
@@ -14,7 +14,7 @@ export interface ControllerEvents<EntityType> {
 }
 
 export class Controller<EntityType> extends TypedEmitter<ControllerEvents<EntityType>> {
-  private readonly model: Model<EntityType>
+  protected readonly model: Model<EntityType>
   private readonly schema: ObjectSchema
 
   constructor (model: Model<EntityType>, schema: ObjectSchema) {

--- a/backend/controllers/group-controller.ts
+++ b/backend/controllers/group-controller.ts
@@ -1,0 +1,9 @@
+import { Controller } from './controller.js'
+import mongoose from 'mongoose'
+import { Group, GROUP_MODEL_NAME, groupSchema, groupValidator } from '../models/group.js'
+
+export class GroupController extends Controller<Group> {
+  constructor (db: mongoose.Connection) {
+    super(db.model(GROUP_MODEL_NAME, groupSchema), groupValidator)
+  }
+}

--- a/backend/controllers/manual-chore-controller.ts
+++ b/backend/controllers/manual-chore-controller.ts
@@ -1,6 +1,11 @@
 import { Controller, Doc } from './controller.js'
-import { QueryCursor } from 'mongoose'
-import { ManualChore, manualChoreModel, manualChoreValidator } from '../models/manual-chore.js'
+import mongoose, { QueryCursor } from 'mongoose'
+import {
+  MANUAL_CHORE_MODEL_NAME,
+  ManualChore,
+  manualChoreSchema,
+  manualChoreValidator
+} from '../models/manual-chore.js'
 import { Scoreboard } from '../models/scoreboard.js'
 
 export interface ManualChoreDependencies {
@@ -8,12 +13,12 @@ export interface ManualChoreDependencies {
 }
 
 export class ManualChoreController extends Controller<ManualChore> {
-  constructor (dependencies: ManualChoreDependencies) {
-    super(manualChoreModel, manualChoreValidator)
+  constructor (db: mongoose.Connection, dependencies: ManualChoreDependencies) {
+    super(db.model(MANUAL_CHORE_MODEL_NAME, manualChoreSchema), manualChoreValidator)
 
     // unset scoreboards when they are deleted
     dependencies.scoreboard.on('deleted', async (other) => {
-      const cursor: QueryCursor<Doc<ManualChore>> = manualChoreModel.find({
+      const cursor: QueryCursor<Doc<ManualChore>> = this.model.find({
         scoreboardId: other._id
       }).cursor()
       await cursor.eachAsync(async (item) => {

--- a/backend/controllers/member-controller.ts
+++ b/backend/controllers/member-controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Doc } from './controller.js'
-import { Member, memberModel, memberValidator } from '../models/member.js'
+import { Member, MEMBER_MODEL_NAME, memberSchema, memberValidator } from '../models/member.js'
 import mongoose, { QueryCursor } from 'mongoose'
 import { Group } from '../models/group.js'
 
@@ -15,12 +15,12 @@ export interface MemberDependencies {
 }
 
 export class MemberController extends Controller<Member> {
-  constructor (dependencies: MemberDependencies) {
-    super(memberModel, memberValidator)
+  constructor (db: mongoose.Connection, dependencies: MemberDependencies) {
+    super(db.model(MEMBER_MODEL_NAME, memberSchema), memberValidator)
 
     // remove groups for members when they are deleted
     dependencies.group.on('deleted', async (other) => {
-      const cursor: QueryCursor<Doc<Member>> = memberModel.find({
+      const cursor: QueryCursor<Doc<Member>> = this.model.find({
         groups: other._id
       }).cursor()
       await cursor.eachAsync(async (item) => {

--- a/backend/controllers/periodic-chore-controller.ts
+++ b/backend/controllers/periodic-chore-controller.ts
@@ -1,19 +1,24 @@
 import { Controller, Doc } from './controller.js'
-import { PeriodicChore, periodicChoreModel, periodicChoreValidator } from '../models/periodic-chore.js'
+import {
+  PERIODIC_CHORE_MODEL_NAME,
+  PeriodicChore,
+  periodicChoreSchema,
+  periodicChoreValidator
+} from '../models/periodic-chore.js'
 import { Member } from '../models/member.js'
-import { QueryCursor } from 'mongoose'
+import mongoose, { QueryCursor } from 'mongoose'
 
 export interface PeriodicChoreDependencies {
   member: Controller<Member>
 }
 
 export class PeriodicChoreController extends Controller<PeriodicChore> {
-  constructor (dependencies: PeriodicChoreDependencies) {
-    super(periodicChoreModel, periodicChoreValidator)
+  constructor (db: mongoose.Connection, dependencies: PeriodicChoreDependencies) {
+    super(db.model(PERIODIC_CHORE_MODEL_NAME, periodicChoreSchema), periodicChoreValidator)
 
     // remove entries for members when they are deleted
     dependencies.member.on('deleted', async (other) => {
-      const cursor: QueryCursor<Doc<PeriodicChore>> = periodicChoreModel.find({
+      const cursor: QueryCursor<Doc<PeriodicChore>> = this.model.find({
         'entries.memberId': other._id
       }).cursor()
       await cursor.eachAsync(async (item) => {
@@ -24,7 +29,7 @@ export class PeriodicChoreController extends Controller<PeriodicChore> {
             }
           }
         })
-        const updated = await periodicChoreModel.findById(item._id)
+        const updated = await this.model.findById(item._id)
         if (updated != null) {
           this.emit('updated', updated)
         }

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -1,48 +1,60 @@
 import mongoose from 'mongoose'
 import { Environment } from './environment.js'
 import { Controller } from './controllers/controller.js'
-import { groupModel, groupValidator } from './models/group.js'
+import { MemberController } from './controllers/member-controller.js'
+import { GroupController } from './controllers/group-controller.js'
 import { ScoreboardController } from './controllers/scoreboard-controller.js'
 import { ManualChoreController } from './controllers/manual-chore-controller.js'
 import { PeriodicChoreController } from './controllers/periodic-chore-controller.js'
 
 import { createRouter, createErrorHandler } from './api/api.js'
 import { handler as wsHandler } from './websocket/handler.js'
-import { MemberController } from './controllers/member-controller.js'
+import { Router } from 'express'
+import WebSocket from 'ws'
 
 export { Environment } from './environment.js'
 
-const groupsController = new Controller(groupModel, groupValidator)
-const membersController = new MemberController({
-  group: groupsController
-})
-const scoreboardsController = new ScoreboardController({
-  member: membersController
-})
-const manualChoresController = new ManualChoreController({
-  scoreboard: scoreboardsController
-})
-const periodicChoresController = new PeriodicChoreController({
-  member: membersController
-})
-
-const controllers: Record<string, Controller<any>> = {
-  groups: groupsController,
-  members: membersController,
-  scoreboards: scoreboardsController,
-  'manual-chores': manualChoresController,
-  'periodic-chores': periodicChoresController
+export interface Backend {
+  readonly createApiRouter: () => Router
+  readonly createApiErrorHandler: typeof createErrorHandler
+  readonly webSocketHandler: (ws: WebSocket, pageVersion?: string) => void
 }
 
-export async function init (env: Environment): Promise<void> {
+function createControllers (db: mongoose.Connection): Record<string, Controller<any>> {
+  const groupsController = new GroupController(db)
+  const membersController = new MemberController(db, {
+    group: groupsController
+  })
+  const scoreboardsController = new ScoreboardController(db, {
+    member: membersController
+  })
+  const manualChoresController = new ManualChoreController(db, {
+    scoreboard: scoreboardsController
+  })
+  const periodicChoresController = new PeriodicChoreController(db, {
+    member: membersController
+  })
+
+  return {
+    groups: groupsController,
+    members: membersController,
+    scoreboards: scoreboardsController,
+    'manual-chores': manualChoresController,
+    'periodic-chores': periodicChoresController
+  }
+}
+
+export async function init (env: Environment): Promise<Backend> {
   mongoose.set('toJSON', {
     versionKey: false
   })
 
-  await mongoose.connect(env.MONGODB_URI ?? 'mongodb://localhost/wgsystem')
+  const db = await mongoose.createConnection(env.MONGODB_URI ?? 'mongodb://localhost/wgsystem').asPromise()
+  const controllers = createControllers(db)
+
+  return {
+    createApiRouter: createRouter.bind(undefined, controllers),
+    createApiErrorHandler: createErrorHandler,
+    webSocketHandler: wsHandler.bind(undefined, controllers)
+  }
 }
-
-export const createApiRouter = createRouter.bind(undefined, controllers)
-export const createApiErrorHandler = createErrorHandler
-
-export const webSocketHandler = wsHandler.bind(undefined, controllers)

--- a/backend/models/group.ts
+++ b/backend/models/group.ts
@@ -6,12 +6,14 @@ export interface Group {
   name: string
 }
 
-export const groupModel = mongoose.model('Group', new mongoose.Schema<Group>({
+export const GROUP_MODEL_NAME = 'Group'
+
+export const groupSchema = new mongoose.Schema<Group>({
   name: {
     type: String,
     required: true
   }
-}))
+})
 
 export const groupValidator = Joi.object({
   _id: idValidator.required(),

--- a/backend/models/manual-chore.ts
+++ b/backend/models/manual-chore.ts
@@ -1,6 +1,6 @@
 import mongoose from 'mongoose'
 import Joi from 'joi'
-import { scoreboardModel } from './scoreboard.js'
+import { SCOREBOARD_MODEL_NAME } from './scoreboard.js'
 import { idValidator } from './common.js'
 
 export interface ManualChore {
@@ -9,7 +9,9 @@ export interface ManualChore {
   scoreboardId: mongoose.Types.ObjectId | null
 }
 
-export const manualChoreModel = mongoose.model('ManualChore', new mongoose.Schema<ManualChore>({
+export const MANUAL_CHORE_MODEL_NAME = 'ManualChore'
+
+export const manualChoreSchema = new mongoose.Schema<ManualChore>({
   name: {
     type: String,
     required: true
@@ -22,9 +24,9 @@ export const manualChoreModel = mongoose.model('ManualChore', new mongoose.Schem
   scoreboardId: {
     type: mongoose.Schema.Types.ObjectId,
     required: false,
-    ref: scoreboardModel
+    ref: SCOREBOARD_MODEL_NAME
   }
-}))
+})
 
 export const manualChoreValidator = Joi.object({
   _id: idValidator.required(),

--- a/backend/models/member.ts
+++ b/backend/models/member.ts
@@ -1,7 +1,7 @@
 import mongoose from 'mongoose'
 import Joi from 'joi'
 import { idValidator } from './common.js'
-import { groupModel } from './group.js'
+import { GROUP_MODEL_NAME } from './group.js'
 
 const HEX_COLOR_REGEXP = /^#[0-9a-fA-F]{6}$/
 
@@ -12,7 +12,9 @@ export interface Member {
   groups: mongoose.Types.ObjectId[]
 }
 
-export const memberModel = mongoose.model('Member', new mongoose.Schema<Member>({
+export const MEMBER_MODEL_NAME = 'Member'
+
+export const memberSchema = new mongoose.Schema<Member>({
   name: {
     type: String,
     required: true
@@ -29,10 +31,10 @@ export const memberModel = mongoose.model('Member', new mongoose.Schema<Member>(
   groups: [
     {
       type: mongoose.Schema.Types.ObjectId,
-      ref: groupModel
+      ref: GROUP_MODEL_NAME
     }
   ]
-}))
+})
 
 export const memberValidator = Joi.object({
   _id: idValidator.required(),

--- a/backend/models/periodic-chore.ts
+++ b/backend/models/periodic-chore.ts
@@ -1,8 +1,8 @@
 import mongoose from 'mongoose'
 import Joi from 'joi'
 import { idValidator } from './common.js'
-import { memberModel } from './member.js'
-import { groupModel } from './group.js'
+import { MEMBER_MODEL_NAME } from './member.js'
+import { GROUP_MODEL_NAME } from './group.js'
 
 export interface PeriodicChoreEntry {
   memberId: mongoose.Types.ObjectId
@@ -16,7 +16,9 @@ export interface PeriodicChore {
   entries: PeriodicChoreEntry[]
 }
 
-export const periodicChoreModel = mongoose.model('PeriodicChore', new mongoose.Schema<PeriodicChore>({
+export const PERIODIC_CHORE_MODEL_NAME = 'PeriodicChore'
+
+export const periodicChoreSchema = new mongoose.Schema<PeriodicChore>({
   name: {
     type: String,
     required: true
@@ -29,7 +31,7 @@ export const periodicChoreModel = mongoose.model('PeriodicChore', new mongoose.S
   groups: [
     {
       type: mongoose.Schema.Types.ObjectId,
-      ref: groupModel
+      ref: GROUP_MODEL_NAME
     }
   ],
   entries: [
@@ -38,7 +40,7 @@ export const periodicChoreModel = mongoose.model('PeriodicChore', new mongoose.S
       memberId: {
         type: mongoose.Schema.Types.ObjectId,
         required: true,
-        ref: memberModel
+        ref: MEMBER_MODEL_NAME
       },
       date: {
         type: String,
@@ -46,7 +48,7 @@ export const periodicChoreModel = mongoose.model('PeriodicChore', new mongoose.S
       }
     }
   ]
-}))
+})
 
 export const periodicChoreValidator = Joi.object({
   _id: idValidator.required(),

--- a/backend/models/scoreboard.ts
+++ b/backend/models/scoreboard.ts
@@ -1,5 +1,5 @@
 import mongoose from 'mongoose'
-import { memberModel } from './member.js'
+import { MEMBER_MODEL_NAME } from './member.js'
 import Joi from 'joi'
 import { idValidator } from './common.js'
 
@@ -14,7 +14,9 @@ export interface Scoreboard {
   scores: ScoreboardEntry[]
 }
 
-export const scoreboardModel = mongoose.model('Scoreboard', new mongoose.Schema<Scoreboard>({
+export const SCOREBOARD_MODEL_NAME = 'Scoreboard'
+
+export const scoreboardSchema = new mongoose.Schema<Scoreboard>({
   name: {
     type: String,
     required: true
@@ -25,7 +27,7 @@ export const scoreboardModel = mongoose.model('Scoreboard', new mongoose.Schema<
       memberId: {
         type: mongoose.Schema.Types.ObjectId,
         required: true,
-        ref: memberModel
+        ref: MEMBER_MODEL_NAME
       },
       offset: {
         type: Number,
@@ -37,7 +39,7 @@ export const scoreboardModel = mongoose.model('Scoreboard', new mongoose.Schema<
       }
     }
   ]
-}))
+})
 
 export const scoreboardValidator = Joi.object({
   _id: idValidator.required(),

--- a/server.ts
+++ b/server.ts
@@ -5,7 +5,7 @@ import fs from 'fs'
 import { WebSocketServer } from 'ws'
 
 // this works because 'backend' is listed as a workspace in package.json
-import { init, createApiRouter, createApiErrorHandler, webSocketHandler, Environment } from 'backend'
+import { init, Environment } from 'backend'
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -48,7 +48,7 @@ async function getPageVersion (): Promise<string | undefined> {
 
 async function start (): Promise<void> {
   const pageVersion = await getPageVersion()
-  await init(process.env as Environment)
+  const { createApiRouter, createApiErrorHandler, webSocketHandler } = await init(process.env as Environment)
 
   const app = express()
 


### PR DESCRIPTION
Models are now created by their respective controllers. They are
instantiated on a specific mongoose.Connection, instead of using the
default connection, making them potentially testable.