### PR TITLE
feat: Add 'omniwheel' dependency for proper signal handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,5 +48,6 @@ EXPOSE 8080
 # - run as non-root user
 USER node
 
-# - start the server ("production" skips the build step)
-CMD ["npm", "run", "production"]
+# start the server (this is similar to "npm run production", but NPM does not
+# forward signals correctly, while Node does)
+CMD ["node", "build/server.js"]

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -18,6 +18,7 @@ export interface Backend {
   readonly createApiRouter: () => Router
   readonly createApiErrorHandler: typeof createErrorHandler
   readonly webSocketHandler: (ws: WebSocket, pageVersion?: string) => void
+  readonly stop: () => Promise<void>
 }
 
 function createControllers (db: mongoose.Connection): Record<string, Controller<any>> {
@@ -55,6 +56,7 @@ export async function init (env: Environment): Promise<Backend> {
   return {
     createApiRouter: createRouter.bind(undefined, controllers),
     createApiErrorHandler: createErrorHandler,
-    webSocketHandler: wsHandler.bind(undefined, controllers)
+    webSocketHandler: wsHandler.bind(undefined, controllers),
+    stop: async () => await db.close()
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       ],
       "dependencies": {
         "express": "4.17.3",
+        "omniwheel": "0.2.0",
         "ws": "8.5.0"
       },
       "devDependencies": {
@@ -14050,6 +14051,18 @@
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
       "dev": true
+    },
+    "node_modules/omniwheel": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/omniwheel/-/omniwheel-0.2.0.tgz",
+      "integrity": "sha512-jcol2L1JTJX0QkD/FDXD+OFQzwvCjSrcejNWQv/NR3uZOqfwCzmBHnv8oRQK19djZVbRP6/+l+XmtkOyS8ckJQ==",
+      "engines": {
+        "node": ">=16",
+        "npm": ">=7"
+      },
+      "peerDependencies": {
+        "express": "^4.17.3"
+      }
     },
     "node_modules/on-finished": {
       "version": "2.3.0",
@@ -34039,6 +34052,12 @@
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
       "dev": true
+    },
+    "omniwheel": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/omniwheel/-/omniwheel-0.2.0.tgz",
+      "integrity": "sha512-jcol2L1JTJX0QkD/FDXD+OFQzwvCjSrcejNWQv/NR3uZOqfwCzmBHnv8oRQK19djZVbRP6/+l+XmtkOyS8ckJQ==",
+      "requires": {}
     },
     "on-finished": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "dependencies": {
     "express": "4.17.3",
+    "omniwheel": "0.2.0",
     "ws": "8.5.0"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es2018",
-    "module": "es2020",
+    "target": "es2020",
+    "module": "es2022",
     "esModuleInterop": true,
     "moduleResolution": "Node",
     "strict": true,


### PR DESCRIPTION
Fixes #174. This patch updates server.ts to make use of top-level await,
splitting the startup logic into four separate functions. Each of these
is responsible for registering termination hooks provided by the newly
added 'omniwheel' dependency. These hooks will be run when SIGTERM or
SIGINT is received, and afterwards, the process will exit.

Dockerfile had to be adapted to use node directly, instead of NPM, since
NPM does not forward signals properly (making it impossible to react to
them in the aforementioned way).