### PR TITLE
Revert "chore(deps): update node.js to v18 (#248)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # dependencies
-FROM node:18-alpine as dependencies
+FROM node:16-alpine as dependencies
 WORKDIR /usr/src/app
 
 COPY package*.json ./
@@ -28,7 +28,7 @@ COPY tsconfig.json ./
 RUN npm run build
 
 # execution
-FROM node:18-alpine
+FROM node:16-alpine
 WORKDIR /usr/src/app
 
 # - install PRODUCTION dependencies


### PR DESCRIPTION
This reverts commit 7a8c3fdab00c356a94ede43777ee307aaf5d3116.

Node 18 seems to be causing issues with the React app build.