### PR TITLE
chore(deps): Remove dependency @types/react-redux

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -46,7 +46,6 @@
     "@types/ms": "0.7.31",
     "@types/react": "18.0.6",
     "@types/react-dom": "18.0.2",
-    "@types/react-redux": "7.1.24",
     "eslint-plugin-react": "7.29.4",
     "eslint-plugin-react-hooks": "4.4.0",
     "http-proxy-middleware": "2.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,6 @@
         "@types/ms": "0.7.31",
         "@types/react": "18.0.6",
         "@types/react-dom": "18.0.2",
-        "@types/react-redux": "7.1.24",
         "eslint-plugin-react": "7.29.4",
         "eslint-plugin-react-hooks": "4.4.0",
         "http-proxy-middleware": "2.0.6",
@@ -3421,18 +3420,6 @@
       "devOptional": true,
       "dependencies": {
         "@types/react": "*"
-      }
-    },
-    "node_modules/@types/react-redux": {
-      "version": "7.1.24",
-      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.24.tgz",
-      "integrity": "sha512-7FkurKcS1k0FHZEtdbbgN8Oc6b+stGSfZYjQGicofJ0j4U0qIn/jaSvnP2pLwZKiai3/17xqqxkkrxTgN8UNbQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/hoist-non-react-statics": "^3.3.0",
-        "@types/react": "*",
-        "hoist-non-react-statics": "^3.3.0",
-        "redux": "^4.0.0"
       }
     },
     "node_modules/@types/resolve": {
@@ -25796,18 +25783,6 @@
         "@types/react": "*"
       }
     },
-    "@types/react-redux": {
-      "version": "7.1.24",
-      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.24.tgz",
-      "integrity": "sha512-7FkurKcS1k0FHZEtdbbgN8Oc6b+stGSfZYjQGicofJ0j4U0qIn/jaSvnP2pLwZKiai3/17xqqxkkrxTgN8UNbQ==",
-      "dev": true,
-      "requires": {
-        "@types/hoist-non-react-statics": "^3.3.0",
-        "@types/react": "*",
-        "hoist-non-react-statics": "^3.3.0",
-        "redux": "^4.0.0"
-      }
-    },
     "@types/resolve": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.8.tgz",
@@ -30956,7 +30931,6 @@
         "@types/ms": "0.7.31",
         "@types/react": "18.0.6",
         "@types/react-dom": "18.0.2",
-        "@types/react-redux": "7.1.24",
         "body-scroll-lock": "4.0.0-beta.0",
         "clsx": "1.1.1",
         "eslint-plugin-react": "7.29.4",


### PR DESCRIPTION
Since v8.0.0, react-redux ships native TypeScript types, obsoleting this
additional @types dependency.