### PR TITLE
chore(ci): Add a CI job to verify that everything builds correctly

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,3 +18,15 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run lint-all
+
+  testbuild:
+    name: Test Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: npm
+      - run: npm ci
+      - run: npm run build-all


### PR DESCRIPTION
We've had build failures in the past due to dependency updates, that
only manifested themselves once GitHub Actions tried to create the
Docker image. With this patch, we'll create a throwaway build on every
change to ensure these things don't go unnoticed until too late.