### PR TITLE
chore(tsconfig): Set "lib" explicitly to avoid DOM types in global

### DIFF
--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es2018",
+    "lib": ["ES2020"],
+    "target": "es2020",
     "module": "es2020",
     "esModuleInterop": true,
     "moduleResolution": "Node",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "lib": ["ES2020"],
     "target": "es2020",
     "module": "es2022",
     "esModuleInterop": true,


### PR DESCRIPTION
TSConfig "lib" by default includes DOM types which pollute the global namespace. This patch sets "lib" explicitly to avoid this behavior for the server-side code, which could lead to accidental bugs there.