### PR TITLE
chore: Remove rimraf dev dependency

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "lint": "tsc --noEmit && eslint --ignore-path .gitignore .",
     "lint-fix": "tsc --noEmit && eslint --fix --ignore-path .gitignore .",
-    "build": "rimraf build && tsc"
+    "build": "node -e \"fs.rmSync('./build',{force:true,recursive:true})\" && tsc"
   },
   "dependencies": {
     "joi": "17.8.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "@types/node": "18.13.0",
         "@types/ws": "8.5.4",
         "eslint": "8.28.0",
-        "rimraf": "3.0.2",
         "typescript": "4.9.4"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "scripts": {
     "build-all": "npm run build --workspaces --if-present && npm run build",
-    "build": "rimraf build && tsc",
+    "build": "node -e \"fs.rmSync('./build',{force:true,recursive:true})\" && tsc",
     "start": "npm run build-all && npm run production",
     "production": "node build/server.js",
     "dev": "npm start -w frontend",
@@ -36,7 +36,6 @@
     "@types/node": "18.13.0",
     "@types/ws": "8.5.4",
     "eslint": "8.28.0",
-    "rimraf": "3.0.2",
     "typescript": "4.9.4"
   },
   "dependencies": {


### PR DESCRIPTION
Since we depend on Node.js anyway, we can use its CLI to remove the dist directory, without having to depend on a 3rd-party package.