### PR TITLE
fix(frontend): Set type to "module" to let Vite build in ESM mode

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,7 @@
   "name": "frontend",
   "version": "0.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "lint": "tsc --noEmit -p tsconfig.lint.json && eslint --ignore-path .gitignore . && stylelint --ignore-path .gitignore \"**/*.css\"",
     "lint-fix": "tsc --noEmit -p tsconfig.lint.json && eslint --fix --ignore-path .gitignore . && stylelint --fix --ignore-path .gitignore \"**/*.css\"",

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,6 +1,8 @@
-module.exports = {
+const config = {
   plugins: {
     tailwindcss: {},
     autoprefixer: {}
   }
 }
+
+export default config

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,10 +1,10 @@
-const plugin = require('tailwindcss/plugin')
+import type { Config } from 'tailwindcss'
+import plugin from 'tailwindcss/plugin'
 
-/** @type {import('tailwindcss').Config} */
-module.exports = {
+export default {
   content: [
-    "./index.html",
-    "./src/**/*.{js,ts,jsx,tsx}"
+    './index.html',
+    './src/**/*.{js,ts,jsx,tsx}'
   ],
   theme: {
     extend: {}
@@ -15,4 +15,4 @@ module.exports = {
       addVariant('hocus', ['&:hover', '&:focus'])
     })
   ]
-}
+} satisfies Config

--- a/frontend/tsconfig.lint.json
+++ b/frontend/tsconfig.lint.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "include": [
     "src",
-    "vite.config.ts"
+    "vite.config.ts",
+    "tailwind.config.ts"
   ]
 }


### PR DESCRIPTION
Up until now the project ran in CommonJS mode, which is now deprecated by Vite v5:

> The CJS build of Vite's Node API is deprecated. See
> https://vitejs.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated
> for more details.

Set the type to "module" to fix this, and migrate Tailwind and PostCSS configs to more appropriate formats.