### PR TITLE
fix(frontend): Avoid using Array.prototype.at()

### DIFF
--- a/frontend/.eslintrc.yml
+++ b/frontend/.eslintrc.yml
@@ -35,3 +35,5 @@ rules:
   react/void-dom-elements-no-children: ['error']
   react/no-unstable-nested-components: ['error']
   react/prop-types: ['error', { ignore: ['children'] }]
+  # not supported by older Chrome versions
+  unicorn/prefer-at: ['off']

--- a/frontend/src/components/home/PeriodicChoreBox.tsx
+++ b/frontend/src/components/home/PeriodicChoreBox.tsx
@@ -26,7 +26,7 @@ const URGENCY_THRESHOLD = 0.75
  * @returns The formatted string, containing member name and date of completion.
  */
 function useRecentlyCompletedString (chore: PeriodicChore): string {
-  const last = chore.entries.at(-1)
+  const last = chore.entries[chore.entries.length - 1]
 
   const lastMember = useEntityById(selectMembers, last?.memberId)
   // get only date part from ISO date-time string

--- a/frontend/src/globals.d.ts
+++ b/frontend/src/globals.d.ts
@@ -1,0 +1,5 @@
+// This is an interface from @types/node that (unfortunately) adds methods to the global scope
+// which aren't supported in the targeted ECMAScript version.
+interface RelativeIndexable {
+  at: never
+}

--- a/frontend/src/hooks/periodic-chores/use-days-since-last.ts
+++ b/frontend/src/hooks/periodic-chores/use-days-since-last.ts
@@ -15,7 +15,7 @@ const UPDATE_PERIOD = ms('1 hour')
  * @returns The number of days that have passed.
  */
 export function useDaysSinceLast (chore: PeriodicChore): number | undefined {
-  const last = chore.entries.at(-1)
+  const last = chore.entries[chore.entries.length - 1]
 
   return useIntervalMemo(UPDATE_PERIOD, () => {
     if (last == null) {

--- a/frontend/src/hooks/periodic-chores/use-planned-entry.ts
+++ b/frontend/src/hooks/periodic-chores/use-planned-entry.ts
@@ -62,7 +62,7 @@ function usePreferredMember (chore: PeriodicChore): Member | undefined {
  * @returns The upcoming completion information.
  */
 export function usePlannedEntry (chore: PeriodicChore): PlannedEntry | undefined {
-  const last = chore.entries.at(-1)
+  const last = chore.entries[chore.entries.length - 1]
   const member = usePreferredMember(chore)
 
   return useIntervalMemo(UPDATE_PERIOD, () => {


### PR DESCRIPTION
This was the second regression regarding `.at()` - the first one was fixed in #612.

This particular regression was caused by #762.

To hopefully prevent a third time, an environment declaration is added to override the relevant interface from `@types/node` such that calls to `.at()` are not allowed.