### PR TITLE
fix: Optimize Docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,17 +10,17 @@ RUN npm ci
 # each component is built separately to enable aggressive caching and parallelism
 
 # build the backend
-FROM dependencies as build-backend
+FROM dependencies AS build-backend
 COPY backend ./backend
 RUN npm run build -w backend
 
 # build the frontend
-FROM dependencies as build-frontend
+FROM dependencies AS build-frontend
 COPY frontend ./frontend
 RUN npm run build -w frontend
 
 # now build the entire server
-FROM dependencies as build
+FROM dependencies AS build
 COPY --from=build-backend /usr/src/app/backend ./backend
 COPY --from=build-frontend /usr/src/app/frontend ./frontend
 COPY server.ts ./
@@ -31,12 +31,14 @@ RUN npm run build
 FROM node:22.11.0-alpine
 WORKDIR /usr/src/app
 
-# - install PRODUCTION dependencies
+RUN apk add --no-cache tini
+
+# - install production dependencies
 COPY package*.json ./
 COPY backend/package*.json ./backend/
 COPY frontend/package*.json ./frontend/
-RUN npm ci --omit=dev \
-  && apk add --no-cache tini
+RUN npm ci --omit=dev --include-workspace-root --workspace=backend \
+    && npm cache clean --force
 
 # - add the already compiled code
 COPY --from=build /usr/src/app/backend/build ./backend/build


### PR DESCRIPTION
The image is reduced from 212 to 182 MiB (-14%) when we avoid installation of frontend dependencies in the final layer (since the frontend is already bundled)  and clean the npm cache after installation.