### PR TITLE
fix: Set enable-source-maps and disable-proto options

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,4 +53,4 @@ USER node
 
 # use tini as init process since Node.js isn't designed to be run as PID 1
 ENTRYPOINT ["/sbin/tini", "--"]
-CMD ["node", "build/server.js"]
+CMD ["node", "--enable-source-maps", "--disable-proto=delete", "build/server.js"]

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -8,6 +8,7 @@
     "strict": true,
     "declaration": true,
     "skipLibCheck": true,
+    "inlineSourceMap": true,
     "outDir": "./build"
   },
   "exclude": [

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build-all": "npm run build --workspaces --if-present && npm run build",
     "build": "node -e \"fs.rmSync('./build',{force:true,recursive:true})\" && tsc",
     "start": "npm run build-all && npm run production",
-    "production": "node build/server.js",
+    "production": "node --enable-source-maps --disable-proto=delete build/server.js",
     "dev": "npm start -w frontend",
     "lint-all": "npm run lint --workspaces --if-present",
     "lint-fix-all": "npm run lint-fix --workspaces --if-present"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "esModuleInterop": true,
     "moduleResolution": "Node",
     "strict": true,
+    "inlineSourceMap": true,
     "outDir": "./build"
   },
   "include": [


### PR DESCRIPTION
Let error stack traces reflect the location in the TypeScript source code, not the generated JS. Delete the `Object.prototype.__proto__` property to reduce the surface for prototype pollution attacks.